### PR TITLE
feat: Add support for WEBP cover art

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/dweymouth/go-subsonic
 
 go 1.13
+
+require (
+	golang.org/x/image v0.13.0
+)

--- a/subsonic/retrieval.go
+++ b/subsonic/retrieval.go
@@ -13,6 +13,8 @@ import (
 	_ "image/gif"
 	_ "image/jpeg"
 	_ "image/png"
+
+	_ "golang.org/x/image/webp"
 )
 
 // Stream returns the contents of a song, optionally transcoded, from the server.


### PR DESCRIPTION
Currently, for Subsonic cover arts using `webp` format, Supersonic fails with error:

```
error fetching image: image: unknown format
```

Just adding `image/webp` is enough for webp images to start working. This has been tested using a Navidrome instance.

It has the side effect of also understanding the Navidrome's default cover art (gray star) when a resource doesn't have a custom cover.