### PR TITLE
feat: Add support for Sharing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,10 +118,10 @@ If you intend on testing with your own server, modify the top-level TestSubsonic
 
 ## Sharing
 
-- [ ] getShares (1.6.0)
-- [ ] createShare (1.6.0)
-- [ ] updateShare (1.6.0)
-- [ ] deleteShare (1.6.0)
+- [x] getShares (1.6.0)
+- [x] createShare (1.6.0)
+- [x] updateShare (1.6.0)
+- [x] deleteShare (1.6.0)
 
 ## Podcast
 

--- a/subsonic/docker-compose.yml
+++ b/subsonic/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       ND_SCANINTERVAL: 1m
       ND_LOGLEVEL: info
       ND_SESSIONTIMEOUT: 24h
+      ND_ENABLESHARING: true
       ND_BASEURL: ""
     volumes:
       - "./build/data:/data"

--- a/subsonic/live_test.go
+++ b/subsonic/live_test.go
@@ -161,6 +161,7 @@ func TestNavidrome(t *testing.T) {
 	runPlaylistTests(client, t)
 	runRetrievalTests(client, t)
 	runSearchTests(client, t)
+	runSharingTests(client, t)
 	runAnnotationTests(client, t)
 }
 
@@ -181,6 +182,7 @@ func TestAirsonic(t *testing.T) {
 	runPlaylistTests(client, t)
 	runRetrievalTests(client, t)
 	runSearchTests(client, t)
+	runSharingTests(client, t)
 	runAnnotationTests(client, t)
 
 	runAirsonicTests(client, t)
@@ -205,6 +207,7 @@ func TestSubsonic(t *testing.T) {
 	runListsTests(client, t)
 	runRetrievalTests(client, t)
 	runSearchTests(client, t)
+	runSharingTests(client, t)
 	runAnnotationTests(client, t)
 
 	runAirsonicTests(client, t)

--- a/subsonic/models.go
+++ b/subsonic/models.go
@@ -730,6 +730,7 @@ type SearchResult3 struct {
 }
 
 type Share struct {
+	ID          string    `xml:"id,attr"`
 	Entry       []*Child  `xml:"entry,omitempty"`
 	Url         string    `xml:"url,attr"`
 	Description string    `xml:"description,attr,omitempty"`

--- a/subsonic/sharing.go
+++ b/subsonic/sharing.go
@@ -1,0 +1,59 @@
+package subsonic
+
+// GetShares returns information about shared media this user is allowed to manage.
+func (c *Client) GetShares() ([]*Share, error) {
+	resp, err := c.Get("getShares", nil)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Shares.Share, nil
+}
+
+// CreateShare creates a public URL that can be used by anyone to stream music or video from the
+// Subsonic server. The URL is short and suitable for posting on Facebook, Twitter etc. Note: The
+// user must be authorized to share.
+//
+// Optional Parameters:
+//
+//	description: A user-defined description that will be displayed to people visiting the shared media.
+//	expires:     The time at which the share expires. Given as milliseconds since 1970.
+func (c *Client) CreateShare(id string, parameters map[string]string) (*Share, error) {
+	params := make(map[string]string)
+	params["id"] = id
+	for k, v := range parameters {
+		params[k] = v
+	}
+	resp, err := c.Get("createShare", params)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Shares.Share[0], nil
+}
+
+// UpdateShare updates the description and/or expiration date for an existing share.
+//
+// Optional Parameters:
+//
+//	description: A user-defined description that will be displayed to people visiting the shared media.
+//	expires:     The time at which the share expires. Given as milliseconds since 1970, or zero to remove the expiration.
+func (c *Client) UpdateShare(id string, parameters map[string]string) error {
+	params := make(map[string]string)
+	params["id"] = id
+	for k, v := range parameters {
+		params[k] = v
+	}
+	_, err := c.Get("updateShare", params)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// DeleteShare deletes an existing share.
+func (c *Client) DeleteShare(id string) error {
+	_, err := c.Get("deleteShare", map[string]string{"id": id})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/subsonic/sharing_test.go
+++ b/subsonic/sharing_test.go
@@ -1,0 +1,100 @@
+package subsonic
+
+import (
+	"strconv"
+	"testing"
+	"time"
+)
+
+func runSharingTests(client Client, t *testing.T) {
+	sampleAlbum := getSampleAlbum(client)
+
+	t.Run("GetShares", func(t *testing.T) {
+		_, err := client.GetShares()
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("CreateShare", func(t *testing.T) {
+		description := "Test share"
+		expires := time.Now().UTC().Round(time.Millisecond).Add(time.Hour)
+		expiresStr := strconv.FormatInt(expires.UnixMilli(), 10)
+		share, err := client.CreateShare(sampleAlbum.ID, map[string]string{"description": description, "expires": expiresStr})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if share == nil {
+			t.Fatal("No share returned")
+		}
+		if len(share.Entry) != 1 {
+			t.Fatalf("Expected 1 entry, got %d", len(share.Entry))
+		}
+		if share.Entry[0].ID != sampleAlbum.ID {
+			t.Errorf("Expected ID %q, got %q", sampleAlbum.ID, share.Entry[0].ID)
+		}
+		if share.Description != description {
+			t.Errorf("Expected description %q, got %q", description, share.Description)
+		}
+		if share.Expires != expires {
+			t.Errorf("Expected expires %q, got %q", expires, share.Expires)
+		}
+	})
+
+	t.Run("UpdateShare", func(t *testing.T) {
+		description := "Test share"
+		expires := time.Now().UTC().Round(time.Millisecond).Add(time.Hour)
+		expiresStr := strconv.FormatInt(expires.UnixMilli(), 10)
+		share, err := client.CreateShare(sampleAlbum.ID, map[string]string{"description": description, "expires": expiresStr})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		newDescription := "Updated share"
+		newExpires := time.Now().UTC().Round(time.Millisecond).Add(3 * time.Hour)
+		newExpiresStr := strconv.FormatInt(newExpires.UnixMilli(), 10)
+		err = client.UpdateShare(share.ID, map[string]string{"description": newDescription, "expires": newExpiresStr})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		shares, err := client.GetShares()
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, s := range shares {
+			if s.ID == share.ID {
+				if s.Description != newDescription {
+					t.Errorf("Expected description %q, got %q", newDescription, s.Description)
+				}
+				if s.Expires != newExpires {
+					t.Errorf("Expected expires %q, got %q", newExpires, s.Expires)
+				}
+				return
+			}
+		}
+		t.Fatalf("Share %q not found", share.ID)
+	})
+
+	t.Run("DeleteShare", func(t *testing.T) {
+		share, err := client.CreateShare(sampleAlbum.ID, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = client.DeleteShare(share.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		shares, err := client.GetShares()
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, s := range shares {
+			if s.ID == share.ID {
+				t.Fatalf("Share %q not deleted. Share: %+v", share.ID, s)
+			}
+		}
+	})
+}


### PR DESCRIPTION
Add implementation for:

- `getShares`
- `createShare`
- `updateShare`
- `deleteShare`

Testing:

* Navidrome: Tests pass.
* Airsonic: Tests fail with error `Error #0: Access denied to file /airsonic`. It seems to be a misconfiguration in the Docker container, and Airsonic tries to access the filesystem to retrieve the provided media ids [1]
* Subsonic: Tests fail with error `Error #50: guest5 is not authorized to share media.`. This should be expected unless the Demo server configuration is changed.

[1] https://github.com/airsonic/airsonic/blob/5ccca059d5cfe3dd19734c27861b434ea21b43d8/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java#L1850