### PR TITLE
Add JSON response format support

### DIFF
--- a/subsonic/client.go
+++ b/subsonic/client.go
@@ -11,6 +11,7 @@ package subsonic
 
 import (
 	"crypto/md5"
+	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -39,6 +40,7 @@ type Client struct {
 	ClientName          string
 	UserAgent           string
 	PasswordAuth        bool
+	UseJSON             bool
 	RequestedAPIVersion string
 
 	openSubsonicExtensions []*OpenSubsonicExtension
@@ -87,7 +89,7 @@ func (s *Client) Authenticate(password string) error {
 		return err
 	}
 	defer resp.Body.Close()
-	subsonicResp, err := unmarshalResponse(resp.Body)
+	subsonicResp, err := s.unmarshalResponse(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -150,7 +152,11 @@ func (s *Client) setupRequest(method string, endpoint string, params url.Values)
 }
 
 func (s *Client) addDefaultQueryParams(params url.Values) {
-	params.Add("f", "xml")
+	if s.UseJSON {
+		params.Add("f", "json")
+	} else {
+		params.Add("f", "xml")
+	}
 	apiVersion := defaultAPIVersion
 	if s.RequestedAPIVersion != "" {
 		apiVersion = s.RequestedAPIVersion
@@ -173,7 +179,7 @@ func (s *Client) getValues(endpoint string, params url.Values) (*Response, error
 		return nil, err
 	}
 	defer response.Body.Close()
-	parsed, err := unmarshalResponse(response.Body)
+	parsed, err := s.unmarshalResponse(response.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -210,7 +216,7 @@ func (s *Client) postValues(endpoint string, params url.Values) (*Response, erro
 	}
 
 	defer resp.Body.Close()
-	parsed, err := unmarshalResponse(resp.Body)
+	parsed, err := s.unmarshalResponse(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -229,6 +235,25 @@ func (s *Client) buildRequestURL(endpoint string) (*url.URL, error) {
 	return baseUrl, nil
 }
 
+// unmarshalResponse parses a Subsonic API response body into a Response struct.
+// It dispatches to XML or JSON parsing based on the client's UseJSON setting.
+func (s *Client) unmarshalResponse(resp io.Reader) (*Response, error) {
+	responseBody, err := io.ReadAll(resp)
+	if err != nil {
+		return nil, err
+	}
+	if s.UseJSON {
+		return unmarshalJSONResponse(responseBody)
+	}
+	parsed := &Response{}
+	if err = xml.Unmarshal(responseBody, parsed); err != nil {
+		return nil, err
+	}
+	return parsed, nil
+}
+
+// unmarshalResponse parses an XML Subsonic API response. It is kept as a
+// package-level function for use in tests that do not have a Client instance.
 func unmarshalResponse(resp io.Reader) (*Response, error) {
 	responseBody, err := io.ReadAll(resp)
 	if err != nil {
@@ -239,6 +264,16 @@ func unmarshalResponse(resp io.Reader) (*Response, error) {
 		return nil, err
 	}
 	return parsed, nil
+}
+
+func unmarshalJSONResponse(data []byte) (*Response, error) {
+	var wrapper struct {
+		SubsonicResponse Response `json:"subsonic-response"`
+	}
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		return nil, err
+	}
+	return &wrapper.SubsonicResponse, nil
 }
 
 // Ping is used to test connectivity with the server. It returns true if the server is up.

--- a/subsonic/lists_test.go
+++ b/subsonic/lists_test.go
@@ -6,6 +6,8 @@ import (
 	"time"
 )
 
+const albumList2JSON = `{"subsonic-response":{"status":"ok","version":"1.16.1","type":"navidrome","serverVersion":"0.60.3 (34c6f12a)","openSubsonic":true,"albumList2":{"album":[{"id":"2cahnhu6UPen2wbYDm4CHK","name":"8-bit lagerfeuer","artist":"pornophonique","artistId":"24jpYAI4N8TG0cCAYyzZk5","coverArt":"al-2cahnhu6UPen2wbYDm4CHK_640a93a8","songCount":8,"duration":1954,"playCount":3678,"created":"2025-03-26T22:26:48.822020234Z","year":2007,"played":"2026-03-11T03:01:26.176Z","userRating":5,"averageRating":5,"genres":[],"musicBrainzId":"","isCompilation":false,"sortName":"8-bit lagerfeuer","discTitles":[],"originalReleaseDate":{},"releaseDate":{},"releaseTypes":[],"recordLabels":[],"moods":[],"artists":[{"id":"24jpYAI4N8TG0cCAYyzZk5","name":"pornophonique"}],"displayArtist":"pornophonique","explicitStatus":"","version":""},{"id":"6oq0g9th4iTM8a0y0T88tr","name":"netBloc Vol. 24: tiuqottigeloot","artist":"Various Artists","artistId":"63sqASlAfjbGMuLP4JhnZU","coverArt":"al-6oq0g9th4iTM8a0y0T88tr_640a939d","songCount":12,"duration":2615,"playCount":1359,"created":"2025-03-26T22:26:49.228824721Z","year":2009,"genre":"Netlabel","played":"2026-03-11T02:56:45.641Z","userRating":3,"averageRating":3,"genres":[{"name":"Netlabel"}],"musicBrainzId":"","isCompilation":true,"sortName":"netbloc vol. 24: tiuqottigeloot","discTitles":[],"originalReleaseDate":{},"releaseDate":{},"releaseTypes":[],"recordLabels":[],"moods":[],"artists":[{"id":"63sqASlAfjbGMuLP4JhnZU","name":"Various Artists"}],"displayArtist":"Various Artists","explicitStatus":"","version":""},{"id":"3ZE7pthjfyWFhRvT4JKKqJ","name":"Diplomatic Immunity","artist":"The Polish Ambassador","artistId":"3Vy6szDT2gBLGKc8yCcf5r","coverArt":"al-3ZE7pthjfyWFhRvT4JKKqJ_640a9360","songCount":20,"duration":3411,"playCount":1644,"created":"2025-03-26T22:26:47.074844665Z","starred":"2026-02-27T12:01:13.99028623Z","year":2014,"genre":"Electronic","played":"2026-03-11T02:45:21.466Z","userRating":5,"averageRating":5,"genres":[{"name":"Electronic"}],"musicBrainzId":"","isCompilation":false,"sortName":"diplomatic immunity","discTitles":[],"originalReleaseDate":{},"releaseDate":{},"releaseTypes":[],"recordLabels":[{"name":"http://www.jamendo.com"}],"moods":[],"artists":[{"id":"3Vy6szDT2gBLGKc8yCcf5r","name":"The Polish Ambassador"}],"displayArtist":"The Polish Ambassador","explicitStatus":"","version":""},{"id":"3eQTMlSmKBB63P4U2fEELP","name":"Ghosts V: Together","artist":"Nine Inch Nails","artistId":"3GSnSEURz17ltddsamzmSD","coverArt":"al-3eQTMlSmKBB63P4U2fEELP_640a931d","songCount":8,"duration":4218,"playCount":496,"created":"2025-03-26T22:26:45.003988183Z","year":2020,"played":"2026-03-11T02:44:44.59Z","userRating":4,"averageRating":4,"genres":[],"musicBrainzId":"","isCompilation":false,"sortName":"ghosts v: together","discTitles":[],"originalReleaseDate":{},"releaseDate":{},"releaseTypes":[],"recordLabels":[],"moods":[],"artists":[{"id":"3GSnSEURz17ltddsamzmSD","name":"Nine Inch Nails"}],"displayArtist":"Nine Inch Nails","explicitStatus":"","version":""},{"id":"6X1IJN63h7skU4qjlBVM5R","name":"Deflonesoundsystem","artist":"Deflone","artistId":"3eeD9vic30dCDcUq0X2ICg","coverArt":"al-6X1IJN63h7skU4qjlBVM5R_640a92c4","songCount":13,"duration":2922,"playCount":2725,"created":"2025-03-26T22:26:39.580618167Z","year":2008,"genre":"Hip-Hop","played":"2026-03-11T02:43:20.985Z","userRating":4,"averageRating":4,"genres":[{"name":"Hip-Hop"}],"musicBrainzId":"","isCompilation":false,"sortName":"deflonesoundsystem","discTitles":[],"originalReleaseDate":{},"releaseDate":{},"releaseTypes":[],"recordLabels":[],"moods":[],"artists":[{"id":"3eeD9vic30dCDcUq0X2ICg","name":"Deflone"}],"displayArtist":"Deflone","explicitStatus":"","version":""},{"id":"6dGMsiesuYw9lti9yGIGWY","name":"netBloc Vol. 42: Live, The Universe \u0026 Everything","artist":"Various Artists","artistId":"63sqASlAfjbGMuLP4JhnZU","coverArt":"al-6dGMsiesuYw9lti9yGIGWY_640a9396","songCount":11,"duration":2954,"playCount":5320,"created":"2025-03-26T22:26:49.315688846Z","year":2013,"played":"2026-03-11T02:34:50.41Z","userRating":2,"averageRating":2,"genres":[],"musicBrainzId":"","isCompilation":true,"sortName":"netbloc vol. 42: live, the universe \u0026 everything","discTitles":[],"originalReleaseDate":{},"releaseDate":{},"releaseTypes":[],"recordLabels":[],"moods":[],"artists":[{"id":"63sqASlAfjbGMuLP4JhnZU","name":"Various Artists"}],"displayArtist":"Various Artists","explicitStatus":"","version":""},{"id":"4QZO6nBGty9odiq7pUok5n","name":"Love (All I Was Able To Say)","artist":"Back On Earth","artistId":"04HrSORpypcLGNUdQp37gn","coverArt":"al-4QZO6nBGty9odiq7pUok5n_640a9269","songCount":2,"duration":372,"playCount":547,"created":"2025-03-26T22:26:35.129501286Z","starred":"2026-01-07T02:54:34.286241272Z","year":2010,"played":"2026-03-11T02:20:27.790010715Z","userRating":3,"averageRating":3,"genres":[],"musicBrainzId":"","isCompilation":false,"sortName":"love (all i was able to say)","discTitles":[],"originalReleaseDate":{},"releaseDate":{},"releaseTypes":[],"recordLabels":[{"name":"http://www.jamendo.com"}],"moods":[],"artists":[{"id":"04HrSORpypcLGNUdQp37gn","name":"Back On Earth"}],"displayArtist":"Back On Earth","explicitStatus":"","version":""},{"id":"7GZYpfn8wypaTR00LWeNI4","name":"Retroconnaissance","artist":"Ugress","artistId":"5xcMPJdeEgNrGtnzYbzAqb","coverArt":"al-7GZYpfn8wypaTR00LWeNI4_640a9384","songCount":4,"duration":801,"playCount":1477,"created":"2025-03-26T22:26:47.749422855Z","year":2006,"genre":"Electronic","played":"2026-03-11T01:39:26.276Z","userRating":5,"averageRating":5,"genres":[{"name":"Electronic"}],"musicBrainzId":"eb34953a-89a9-4c1e-ab30-7cd24abed2b6","isCompilation":false,"sortName":"retroconnaissance","discTitles":[],"originalReleaseDate":{"year":2006,"month":5,"day":14},"releaseDate":{},"releaseTypes":["ep"],"recordLabels":[{"name":"Uncanny Planet Records"}],"moods":[],"artists":[{"id":"5xcMPJdeEgNrGtnzYbzAqb","name":"Ugress"}],"displayArtist":"Ugress","explicitStatus":"","version":""},{"id":"6IBIiCkWECDiUQQUaQ8X7u","name":"Ghosts VI: Locusts","artist":"Nine Inch Nails","artistId":"3GSnSEURz17ltddsamzmSD","coverArt":"al-6IBIiCkWECDiUQQUaQ8X7u_640a932f","songCount":15,"duration":4984,"playCount":871,"created":"2025-03-26T22:26:47.617732281Z","year":2020,"played":"2026-03-11T01:01:46.267420611Z","userRating":5,"averageRating":5,"genres":[],"musicBrainzId":"","isCompilation":false,"sortName":"ghosts vi: locusts","discTitles":[],"originalReleaseDate":{},"releaseDate":{},"releaseTypes":[],"recordLabels":[],"moods":[],"artists":[{"id":"3GSnSEURz17ltddsamzmSD","name":"Nine Inch Nails"}],"displayArtist":"Nine Inch Nails","explicitStatus":"","version":""},{"id":"2yETGa7bDCWkc5UgZnZ4vm","name":"Detox Static EP","artist":"Front 242","artistId":"5r1GjGktwEMBF5CxujSJRf","coverArt":"al-2yETGa7bDCWkc5UgZnZ4vm_665fc7a7","songCount":7,"duration":1997,"playCount":399,"created":"2025-03-26T22:26:39.54532612Z","starred":"2026-02-01T03:43:52.932177165Z","year":2016,"genre":"Ebm","played":"2026-03-11T00:51:08.662Z","userRating":0,"genres":[{"name":"Ebm"},{"name":"Electro"}],"musicBrainzId":"1628bd05-fdcf-4b88-9c1a-aa6d79b6a23c","isCompilation":false,"sortName":"detox static ep","discTitles":[],"originalReleaseDate":{"year":2016,"month":1,"day":26},"releaseDate":{},"releaseTypes":["ep"],"recordLabels":[{"name":"Alfa Matrix"}],"moods":[],"artists":[{"id":"5r1GjGktwEMBF5CxujSJRf","name":"Front 242"}],"displayArtist":"Front 242","explicitStatus":"","version":""}]}}}`
+
 const openSubsonicAlbumList = `<?xml version="1.0" encoding="utf-8"?>
 <subsonic-response openSubsonic="true" serverVersion="1" status="ok" type="lms" version="1.16.0"><albumList2><album artist="Au5, Danyka Nadeau" coverArt="al-5" created="2023-10-12T18:23:30.000" duration="36" genre="Unknown" id="al-5" isCompilation="false" musicBrainzId="7a4d48b2-66b7-4a93-afbf-2b176a0c92a6" name="Follow You (The Remixes)" originalReleaseDate="2014-07-11" songCount="7" year="2014"><artists id="ar-52" name="Au5"/><artists id="ar-53" name="Danyka Nadeau"/><genres name="Unknown"/><releaseTypes>ep</releaseTypes></album><album artist="Iron Maiden" artistId="ar-45" coverArt="al-4" created="2023-10-12T18:13:19.000" duration="120" genre="Heavy Metal" id="al-4" isCompilation="true" musicBrainzId="1e84b11c-6ea1-4685-87b9-ae35591809d7" name="A Real Live Dead One" originalReleaseDate="1993-03-23" songCount="23" year="1993"><artists id="ar-45" name="Iron Maiden"/><discTitles disc="1" title="Dead One"/><discTitles disc="2" title="Live One"/><genres name="Instrumental"/><genres name="Heavy Metal"/><genres name="Metal"/><releaseTypes>album</releaseTypes><releaseTypes>compilation</releaseTypes><releaseTypes>live</releaseTypes></album><album artist="DJ Banana" artistId="ar-44" coverArt="al-3" created="2023-05-28T18:35:21.000" duration="57" genre="Techno-Industrial" id="al-3" isCompilation="false" musicBrainzId="667851cb-0f84-3fdd-8882-33902fa16aef" name="Fruit Salad Mixtape" originalReleaseDate="" songCount="11" year="2001"><artists id="ar-44" name="DJ Banana"/><genres name="Techno-Industrial"/></album><album artist="Willbe" artistId="ar-2" coverArt="al-2" created="2020-11-19T13:17:03.000" duration="4797" genre="Unknown" id="al-2" isCompilation="true" musicBrainzId="31b3b92b-b212-43de-b57d-7f2961b7cc4a" name="Demovibes 3: Pixels in sequence" originalReleaseDate="2004-06-23" songCount="22" year="2004"><artists id="ar-2" name="Willbe"/><genres name="Electronic"/><genres name="Hip-Hop"/><genres name="Industrial"/><genres name="Rap"/><genres name="Dance"/><genres name="Happy Hardcore"/><genres name="Rave"/><genres name="Trance"/><genres name="Downtempo"/><genres name="Idm"/><genres name="Unknown"/><genres name="Lounge"/><genres name="Breaks"/><genres name="Minimal"/><genres name="Breakbeat"/><genres name="Gothic Metal"/><genres name="Hardcore"/><genres name="House"/><genres name="Instrumental"/><genres name="Ambient"/><genres name="Jazz"/><genres name="Indie"/><genres name="Techno"/><genres name="Stoner Rock"/><genres name="Heavy Metal"/><releaseTypes>album</releaseTypes><releaseTypes>compilation</releaseTypes></album><album artist="Willbe" artistId="ar-2" coverArt="al-1" created="2019-11-27T20:07:27.000" duration="4797" genre="Unknown" id="al-1" isCompilation="true" musicBrainzId="91eaab8e-b472-42f9-a6e4-9e06d0464f31" name="Demovibes 5: The mod inside" originalReleaseDate="2006-04-16" songCount="20" year="2006"><artists id="ar-2" name="Willbe"/><genres name="Disco"/><genres name="Electronic"/><genres name="New Wave"/><genres name="Christian"/><genres name="Hip-Hop"/><genres name="Industrial"/><genres name="Rap"/><genres name="Dance"/><genres name="Happy Hardcore"/><genres name="Rave"/><genres name="Trance"/><genres name="Downtempo"/><genres name="Idm"/><genres name="Unknown"/><genres name="Lounge"/><genres name="Progressive Rock"/><genres name="Psychedelic Rock"/><genres name="Avant-Garde"/><genres name="Drum and Bass"/><genres name="Breaks"/><genres name="Minimal"/><genres name="Breakbeat"/><releaseTypes>album</releaseTypes><releaseTypes>compilation</releaseTypes></album></albumList2></subsonic-response>`
 
@@ -35,6 +37,156 @@ func TestUnmarshalOpenSubsonicAlbumList(t *testing.T) {
 	}
 	if parsed.AlbumList2.Album[1].ReleaseTypes[2] != "live" {
 		t.Error("Did not parse OpenSubsonci releaseTypes attribute correctly")
+	}
+}
+
+func TestUnmarshalJSONAlbumList2(t *testing.T) {
+	parsed, err := unmarshalJSONResponse([]byte(albumList2JSON))
+	if err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	// Top-level response fields
+	if parsed.Status != "ok" {
+		t.Errorf("Wrong status: %s", parsed.Status)
+	}
+	if parsed.Version != "1.16.1" {
+		t.Errorf("Wrong version: %s", parsed.Version)
+	}
+	if !parsed.OpenSubsonic {
+		t.Error("OpenSubsonic should be true")
+	}
+
+	if parsed.AlbumList2 == nil {
+		t.Fatal("AlbumList2 is nil")
+	}
+	albums := parsed.AlbumList2.Album
+	if len(albums) != 10 {
+		t.Fatalf("Expected 10 albums, got %d", len(albums))
+	}
+
+	// [0] "8-bit lagerfeuer" — basic field parsing
+	first := albums[0]
+	if first.ID != "2cahnhu6UPen2wbYDm4CHK" {
+		t.Errorf("Wrong ID: %s", first.ID)
+	}
+	if first.Name != "8-bit lagerfeuer" {
+		t.Errorf("Wrong name: %s", first.Name)
+	}
+	if first.Artist != "pornophonique" {
+		t.Errorf("Wrong artist: %s", first.Artist)
+	}
+	if first.ArtistID != "24jpYAI4N8TG0cCAYyzZk5" {
+		t.Errorf("Wrong artistId: %s", first.ArtistID)
+	}
+	if first.SongCount != 8 {
+		t.Errorf("Wrong songCount: %d", first.SongCount)
+	}
+	if first.Duration != 1954 {
+		t.Errorf("Wrong duration: %d", first.Duration)
+	}
+	if first.PlayCount != 3678 {
+		t.Errorf("Wrong playCount: %d", first.PlayCount)
+	}
+	if first.Year != 2007 {
+		t.Errorf("Wrong year: %d", first.Year)
+	}
+	if first.SortName != "8-bit lagerfeuer" {
+		t.Errorf("Wrong sortName: %s", first.SortName)
+	}
+
+	// Created timestamp — exercises the xsdDateTime JSON unmarshaling path
+	if first.Created.IsZero() {
+		t.Error("Created timestamp was not parsed")
+	}
+	expectedCreated := time.Date(2025, time.March, 26, 22, 26, 48, 0, time.UTC)
+	if first.Created.Year() != expectedCreated.Year() ||
+		first.Created.Month() != expectedCreated.Month() ||
+		first.Created.Day() != expectedCreated.Day() {
+		t.Errorf("Created timestamp wrong: %v", first.Created)
+	}
+
+	// Starred absent on first album, present on third
+	if !first.Starred.IsZero() {
+		t.Error("First album Starred should be zero (not starred)")
+	}
+	starred := albums[2] // "Diplomatic Immunity"
+	if starred.Starred.IsZero() {
+		t.Error("Third album Starred should be set")
+	}
+	if starred.Starred.Year() != 2026 || starred.Starred.Month() != time.February {
+		t.Errorf("Third album Starred timestamp wrong: %v", starred.Starred)
+	}
+
+	// IsCompilation
+	if first.IsCompilation {
+		t.Error("First album IsCompilation should be false")
+	}
+	if !albums[1].IsCompilation { // "netBloc Vol. 24"
+		t.Error("Second album IsCompilation should be true")
+	}
+
+	// Artists (OpenSubsonic extension) — single artist
+	if len(first.Artists) != 1 {
+		t.Fatalf("Expected 1 artist on first album, got %d", len(first.Artists))
+	}
+	if first.Artists[0].Name != "pornophonique" {
+		t.Errorf("Wrong artist name: %s", first.Artists[0].Name)
+	}
+	if first.Artists[0].ID != "24jpYAI4N8TG0cCAYyzZk5" {
+		t.Errorf("Wrong artist ID: %s", first.Artists[0].ID)
+	}
+
+	// Genres — empty slice
+	if len(first.Genres) != 0 {
+		t.Errorf("Expected empty Genres on first album, got %d", len(first.Genres))
+	}
+	// Genres — single entry
+	if len(albums[1].Genres) != 1 {
+		t.Fatalf("Expected 1 genre on second album, got %d", len(albums[1].Genres))
+	}
+	if albums[1].Genres[0].Name != "Netlabel" {
+		t.Errorf("Wrong genre name: %s", albums[1].Genres[0].Name)
+	}
+	// Genres — multiple entries
+	last := albums[9] // "Detox Static EP"
+	if len(last.Genres) != 2 {
+		t.Fatalf("Expected 2 genres on last album, got %d", len(last.Genres))
+	}
+	if last.Genres[0].Name != "Ebm" || last.Genres[1].Name != "Electro" {
+		t.Errorf("Wrong genres on last album: %v", last.Genres)
+	}
+
+	// OriginalReleaseDate with full year/month/day — [7] "Retroconnaissance"
+	retro := albums[7]
+	if retro.Name != "Retroconnaissance" {
+		t.Fatalf("Unexpected album at index 7: %s", retro.Name)
+	}
+	if retro.OriginalReleaseDate == nil {
+		t.Fatal("OriginalReleaseDate should not be nil for Retroconnaissance")
+	}
+	if retro.OriginalReleaseDate.Year == nil || *retro.OriginalReleaseDate.Year != 2006 {
+		t.Errorf("Wrong OriginalReleaseDate year: %v", retro.OriginalReleaseDate.Year)
+	}
+	if retro.OriginalReleaseDate.Month == nil || *retro.OriginalReleaseDate.Month != 5 {
+		t.Errorf("Wrong OriginalReleaseDate month: %v", retro.OriginalReleaseDate.Month)
+	}
+	if retro.OriginalReleaseDate.Day == nil || *retro.OriginalReleaseDate.Day != 14 {
+		t.Errorf("Wrong OriginalReleaseDate day: %v", retro.OriginalReleaseDate.Day)
+	}
+
+	// ReleaseTypes
+	if len(retro.ReleaseTypes) != 1 || retro.ReleaseTypes[0] != "ep" {
+		t.Errorf("Wrong ReleaseTypes for Retroconnaissance: %v", retro.ReleaseTypes)
+	}
+	if len(first.ReleaseTypes) != 0 {
+		t.Errorf("Expected empty ReleaseTypes for first album, got %v", first.ReleaseTypes)
+	}
+
+	// Unicode album name ("& Everything")
+	netbloc42 := albums[5]
+	if netbloc42.Name != "netBloc Vol. 42: Live, The Universe & Everything" {
+		t.Errorf("Unicode escape in album name not decoded correctly: %s", netbloc42.Name)
 	}
 }
 

--- a/subsonic/models.go
+++ b/subsonic/models.go
@@ -11,32 +11,33 @@ package subsonic
 
 import (
 	"bytes"
+	"encoding/json"
 	"encoding/xml"
 	"time"
 )
 
 // AlbumID3 is an album that's organized by music file tags.
 type AlbumID3 struct {
-	ID                  string    `xml:"id,attr"`        // Manually added
-	Song                []*Child  `xml:"song,omitempty"` // Merged from AlbumWithSongsID3
-	Name                string    `xml:"name,attr"`
-	SortName            string    `xml:"sortName,attr,omitempty"` // OpenSubsonic extension
-	Artist              string    `xml:"artist,attr,omitempty"`
-	ArtistID            string    `xml:"artistId,attr,omitempty"`
-	Artists             []IDName  `xml:"artists,omitempty"` // OpenSubsonic extension
-	CoverArt            string    `xml:"coverArt,attr,omitempty"`
-	SongCount           int       `xml:"songCount,attr"`
-	Duration            int       `xml:"duration,attr"`
-	PlayCount           int64     `xml:"playCount,attr,omitempty"`
-	Created             time.Time `xml:"created,attr"`
-	Starred             time.Time `xml:"starred,attr,omitempty"`
-	Year                int       `xml:"year,attr,omitempty"`
-	ReleaseDate         *ItemDate `xml:"releaseDate,omitempty"`         // OpenSubsonic extension
-	OriginalReleaseDate *ItemDate `xml:"originalReleaseDate,omitempty"` // OpenSubsonic extension
-	Genre               string    `xml:"genre,attr,omitempty"`
-	Genres              []IDName  `xml:"genres,omitempty"`       // OpenSubsonic extension
-	ReleaseTypes        []string  `xml:"releaseTypes,omitempty"` // OpenSubsonic extension
-	IsCompilation       bool      `xml:"isCompilation,attr"`     // OpenSubsonic extension
+	ID                  string    `xml:"id,attr"                       json:"id"`
+	Song                []*Child  `xml:"song,omitempty"                json:"song,omitempty"`
+	Name                string    `xml:"name,attr"                     json:"name"`
+	SortName            string    `xml:"sortName,attr,omitempty"       json:"sortName,omitempty"`
+	Artist              string    `xml:"artist,attr,omitempty"         json:"artist,omitempty"`
+	ArtistID            string    `xml:"artistId,attr,omitempty"       json:"artistId,omitempty"`
+	Artists             []IDName  `xml:"artists,omitempty"             json:"artists,omitempty"`
+	CoverArt            string    `xml:"coverArt,attr,omitempty"       json:"coverArt,omitempty"`
+	SongCount           int       `xml:"songCount,attr"                json:"songCount"`
+	Duration            int       `xml:"duration,attr"                 json:"duration"`
+	PlayCount           int64     `xml:"playCount,attr,omitempty"      json:"playCount,omitempty"`
+	Created             time.Time `xml:"created,attr"                  json:"created"`
+	Starred             time.Time `xml:"starred,attr,omitempty"        json:"starred,omitempty"`
+	Year                int       `xml:"year,attr,omitempty"           json:"year,omitempty"`
+	ReleaseDate         *ItemDate `xml:"releaseDate,omitempty"         json:"releaseDate,omitempty"`
+	OriginalReleaseDate *ItemDate `xml:"originalReleaseDate,omitempty" json:"originalReleaseDate,omitempty"`
+	Genre               string    `xml:"genre,attr,omitempty"          json:"genre,omitempty"`
+	Genres              []IDName  `xml:"genres,omitempty"              json:"genres,omitempty"`
+	ReleaseTypes        []string  `xml:"releaseTypes,omitempty"        json:"releaseTypes,omitempty"`
+	IsCompilation       bool      `xml:"isCompilation,attr"            json:"isCompilation,omitempty"`
 }
 
 func (t *AlbumID3) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
@@ -63,33 +64,59 @@ func (t *AlbumID3) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	overlay.Starred = (*xsdDateTime)(&overlay.T.Starred)
 	return d.DecodeElement(&overlay, &start)
 }
+func (t *AlbumID3) MarshalJSON() ([]byte, error) {
+	type T AlbumID3
+	var layout struct {
+		*T
+		Created *xsdDateTime `json:"created"`
+		Starred *xsdDateTime `json:"starred,omitempty"`
+	}
+	layout.T = (*T)(t)
+	layout.Created = (*xsdDateTime)(&t.Created)
+	if !t.Starred.IsZero() {
+		layout.Starred = (*xsdDateTime)(&t.Starred)
+	}
+	return json.Marshal(layout)
+}
+func (t *AlbumID3) UnmarshalJSON(data []byte) error {
+	type T AlbumID3
+	var overlay struct {
+		*T
+		Created *xsdDateTime `json:"created"`
+		Starred *xsdDateTime `json:"starred,omitempty"`
+	}
+	overlay.T = (*T)(t)
+	overlay.Created = (*xsdDateTime)(&overlay.T.Created)
+	overlay.Starred = (*xsdDateTime)(&overlay.T.Starred)
+	return json.Unmarshal(data, &overlay)
+}
 
 // AlbumInfo is a collection of notes and links describing an album.
 type AlbumInfo struct {
-	Notes          string `xml:"notes,omitempty"`
-	MusicBrainzID  string `xml:"musicBrainzId,omitempty"`
-	LastFmUrl      string `xml:"lastFmUrl,omitempty"`
-	SmallImageUrl  string `xml:"smallImageUrl,omitempty"`
-	MediumImageUrl string `xml:"mediumImageUrl,omitempty"`
-	LargeImageUrl  string `xml:"largeImageUrl,omitempty"`
+	Notes          string `xml:"notes,omitempty"          json:"notes,omitempty"`
+	MusicBrainzID  string `xml:"musicBrainzId,omitempty"  json:"musicBrainzId,omitempty"`
+	LastFmUrl      string `xml:"lastFmUrl,omitempty"      json:"lastFmUrl,omitempty"`
+	SmallImageUrl  string `xml:"smallImageUrl,omitempty"  json:"smallImageUrl,omitempty"`
+	MediumImageUrl string `xml:"mediumImageUrl,omitempty" json:"mediumImageUrl,omitempty"`
+	LargeImageUrl  string `xml:"largeImageUrl,omitempty"  json:"largeImageUrl,omitempty"`
 }
 
 type albumList struct {
-	Album []*Child `xml:"album,omitempty"`
+	Album []*Child `xml:"album,omitempty" json:"album,omitempty"`
 }
 
 type albumList2 struct {
-	Album []*AlbumID3 `xml:"album,omitempty"`
+	Album []*AlbumID3 `xml:"album,omitempty" json:"album,omitempty"`
 }
 
 // Artist is an artist from the server, organized in the folders pattern.
 type Artist struct {
-	ID             string    `xml:"id,attr"`
-	Name           string    `xml:"name,attr"`
-	ArtistImageUrl string    `xml:"artistImageUrl,attr,omitempty"`
-	Starred        time.Time `xml:"starred,attr,omitempty"`
-	UserRating     int       `xml:"userRating,attr,omitempty"`
-	AverageRating  float64   `xml:"averageRating,attr,omitempty"`
+	ID             string    `xml:"id,attr"                      json:"id"`
+	Name           string    `xml:"name,attr"                    json:"name"`
+	ArtistImageUrl string    `xml:"artistImageUrl,attr,omitempty" json:"artistImageUrl,omitempty"`
+	Starred        time.Time `xml:"starred,attr,omitempty"       json:"starred,omitempty"`
+	UserRating     int       `xml:"userRating,attr,omitempty"    json:"userRating,omitempty"`
+	AverageRating  float64   `xml:"averageRating,attr,omitempty" json:"averageRating,omitempty"`
 }
 
 func (t *Artist) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
@@ -112,18 +139,40 @@ func (t *Artist) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	overlay.Starred = (*xsdDateTime)(&overlay.T.Starred)
 	return d.DecodeElement(&overlay, &start)
 }
+func (t *Artist) MarshalJSON() ([]byte, error) {
+	type T Artist
+	var layout struct {
+		*T
+		Starred *xsdDateTime `json:"starred,omitempty"`
+	}
+	layout.T = (*T)(t)
+	if !t.Starred.IsZero() {
+		layout.Starred = (*xsdDateTime)(&t.Starred)
+	}
+	return json.Marshal(layout)
+}
+func (t *Artist) UnmarshalJSON(data []byte) error {
+	type T Artist
+	var overlay struct {
+		*T
+		Starred *xsdDateTime `json:"starred,omitempty"`
+	}
+	overlay.T = (*T)(t)
+	overlay.Starred = (*xsdDateTime)(&overlay.T.Starred)
+	return json.Unmarshal(data, &overlay)
+}
 
 // ArtistID3 is an artist from the server, organized by ID3 tag.
 type ArtistID3 struct {
-	ID             string      `xml:"id,attr"`         // Manually added
-	Album          []*AlbumID3 `xml:"album,omitempty"` // Merged with ArtistWithAlbumsID3
-	Name           string      `xml:"name,attr"`
-	CoverArt       string      `xml:"coverArt,attr,omitempty"`
-	ArtistImageUrl string      `xml:"artistImageUrl,attr,omitempty"`
-	AlbumCount     int         `xml:"albumCount,attr"`
-	Starred        time.Time   `xml:"starred,attr,omitempty"`
-	SortName       string      `xml:"sortName,attr,omitempty"`      // OpenSubsonic extension
-	MusicBrainzId  string      `xml:"musicBrainzId,attr,omitempty"` // OpenSubsonic extension
+	ID             string      `xml:"id,attr"                       json:"id"`
+	Album          []*AlbumID3 `xml:"album,omitempty"               json:"album,omitempty"`
+	Name           string      `xml:"name,attr"                     json:"name"`
+	CoverArt       string      `xml:"coverArt,attr,omitempty"       json:"coverArt,omitempty"`
+	ArtistImageUrl string      `xml:"artistImageUrl,attr,omitempty" json:"artistImageUrl,omitempty"`
+	AlbumCount     int         `xml:"albumCount,attr"               json:"albumCount"`
+	Starred        time.Time   `xml:"starred,attr,omitempty"        json:"starred,omitempty"`
+	SortName       string      `xml:"sortName,attr,omitempty"       json:"sortName,omitempty"`
+	MusicBrainzId  string      `xml:"musicBrainzId,attr,omitempty"  json:"musicBrainzId,omitempty"`
 }
 
 func (t *ArtistID3) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
@@ -146,42 +195,64 @@ func (t *ArtistID3) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	overlay.Starred = (*xsdDateTime)(&overlay.T.Starred)
 	return d.DecodeElement(&overlay, &start)
 }
+func (t *ArtistID3) MarshalJSON() ([]byte, error) {
+	type T ArtistID3
+	var layout struct {
+		*T
+		Starred *xsdDateTime `json:"starred,omitempty"`
+	}
+	layout.T = (*T)(t)
+	if !t.Starred.IsZero() {
+		layout.Starred = (*xsdDateTime)(&t.Starred)
+	}
+	return json.Marshal(layout)
+}
+func (t *ArtistID3) UnmarshalJSON(data []byte) error {
+	type T ArtistID3
+	var overlay struct {
+		*T
+		Starred *xsdDateTime `json:"starred,omitempty"`
+	}
+	overlay.T = (*T)(t)
+	overlay.Starred = (*xsdDateTime)(&overlay.T.Starred)
+	return json.Unmarshal(data, &overlay)
+}
 
 // ArtistInfo is all auxillary information about an artist from GetArtistInfo.
 type ArtistInfo struct {
-	SimilarArtist  []*Artist `xml:"similarArtist,omitempty"`
-	Biography      string    `xml:"biography,omitempty"`
-	MusicBrainzID  string    `xml:"musicBrainzId,omitempty"`
-	LastFmUrl      string    `xml:"lastFmUrl,omitempty"`
-	SmallImageUrl  string    `xml:"smallImageUrl,omitempty"`
-	MediumImageUrl string    `xml:"mediumImageUrl,omitempty"`
-	LargeImageUrl  string    `xml:"largeImageUrl,omitempty"`
+	SimilarArtist  []*Artist `xml:"similarArtist,omitempty"  json:"similarArtist,omitempty"`
+	Biography      string    `xml:"biography,omitempty"      json:"biography,omitempty"`
+	MusicBrainzID  string    `xml:"musicBrainzId,omitempty"  json:"musicBrainzId,omitempty"`
+	LastFmUrl      string    `xml:"lastFmUrl,omitempty"      json:"lastFmUrl,omitempty"`
+	SmallImageUrl  string    `xml:"smallImageUrl,omitempty"  json:"smallImageUrl,omitempty"`
+	MediumImageUrl string    `xml:"mediumImageUrl,omitempty" json:"mediumImageUrl,omitempty"`
+	LargeImageUrl  string    `xml:"largeImageUrl,omitempty"  json:"largeImageUrl,omitempty"`
 }
 
 // ArtistInfo2 is all auxillary information about an artist from GetArtistInfo2, with similar artists organized by ID3 tags.
 type ArtistInfo2 struct {
-	SimilarArtist  []*ArtistID3 `xml:"similarArtist,omitempty"`
-	Biography      string       `xml:"biography,omitempty"`
-	MusicBrainzID  string       `xml:"musicBrainzId,omitempty"`
-	LastFmUrl      string       `xml:"lastFmUrl,omitempty"`
-	SmallImageUrl  string       `xml:"smallImageUrl,omitempty"`
-	MediumImageUrl string       `xml:"mediumImageUrl,omitempty"`
-	LargeImageUrl  string       `xml:"largeImageUrl,omitempty"`
+	SimilarArtist  []*ArtistID3 `xml:"similarArtist,omitempty"  json:"similarArtist,omitempty"`
+	Biography      string       `xml:"biography,omitempty"      json:"biography,omitempty"`
+	MusicBrainzID  string       `xml:"musicBrainzId,omitempty"  json:"musicBrainzId,omitempty"`
+	LastFmUrl      string       `xml:"lastFmUrl,omitempty"      json:"lastFmUrl,omitempty"`
+	SmallImageUrl  string       `xml:"smallImageUrl,omitempty"  json:"smallImageUrl,omitempty"`
+	MediumImageUrl string       `xml:"mediumImageUrl,omitempty" json:"mediumImageUrl,omitempty"`
+	LargeImageUrl  string       `xml:"largeImageUrl,omitempty"  json:"largeImageUrl,omitempty"`
 }
 
 // ArtistsID3 is an index of every artist on the server organized by ID3 tag, from getArtists.
 type ArtistsID3 struct {
-	Index           []*IndexID3 `xml:"index,omitempty"`
-	IgnoredArticles string      `xml:"ignoredArticles,attr"`
+	Index           []*IndexID3 `xml:"index,omitempty"       json:"index,omitempty"`
+	IgnoredArticles string      `xml:"ignoredArticles,attr"  json:"ignoredArticles"`
 }
 
 type Bookmark struct {
-	Entry    *Child    `xml:"entry"`
-	Position int64     `xml:"position,attr"`
-	Username string    `xml:"username,attr"`
-	Comment  string    `xml:"comment,attr,omitempty"`
-	Created  time.Time `xml:"created,attr"`
-	Changed  time.Time `xml:"changed,attr"`
+	Entry    *Child    `xml:"entry"              json:"entry"`
+	Position int64     `xml:"position,attr"      json:"position"`
+	Username string    `xml:"username,attr"      json:"username"`
+	Comment  string    `xml:"comment,attr,omitempty" json:"comment,omitempty"`
+	Created  time.Time `xml:"created,attr"       json:"created"`
+	Changed  time.Time `xml:"changed,attr"       json:"changed"`
 }
 
 func (t *Bookmark) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
@@ -208,70 +279,94 @@ func (t *Bookmark) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	overlay.Changed = (*xsdDateTime)(&overlay.T.Changed)
 	return d.DecodeElement(&overlay, &start)
 }
+func (t *Bookmark) MarshalJSON() ([]byte, error) {
+	type T Bookmark
+	var layout struct {
+		*T
+		Created *xsdDateTime `json:"created"`
+		Changed *xsdDateTime `json:"changed"`
+	}
+	layout.T = (*T)(t)
+	layout.Created = (*xsdDateTime)(&t.Created)
+	layout.Changed = (*xsdDateTime)(&t.Changed)
+	return json.Marshal(layout)
+}
+func (t *Bookmark) UnmarshalJSON(data []byte) error {
+	type T Bookmark
+	var overlay struct {
+		*T
+		Created *xsdDateTime `json:"created"`
+		Changed *xsdDateTime `json:"changed"`
+	}
+	overlay.T = (*T)(t)
+	overlay.Created = (*xsdDateTime)(&overlay.T.Created)
+	overlay.Changed = (*xsdDateTime)(&overlay.T.Changed)
+	return json.Unmarshal(data, &overlay)
+}
 
 type bookmarks struct {
-	Bookmark []*Bookmark `xml:"bookmark,omitempty"`
+	Bookmark []*Bookmark `xml:"bookmark,omitempty" json:"bookmark,omitempty"`
 }
 
 type ChatMessage struct {
-	Username string `xml:"username,attr"`
-	Time     int64  `xml:"time,attr"`
-	Message  string `xml:"message,attr"`
+	Username string `xml:"username,attr" json:"username"`
+	Time     int64  `xml:"time,attr"     json:"time"`
+	Message  string `xml:"message,attr"  json:"message"`
 }
 
 type chatMessages struct {
-	ChatMessage []*ChatMessage `xml:"chatMessage,omitempty"`
+	ChatMessage []*ChatMessage `xml:"chatMessage,omitempty" json:"chatMessage,omitempty"`
 }
 
 // Child is a song, or a generic entry in the hierarchical directory structure of the database.
 // You can tell if Child is used as a song contextually based on what it was returned by, or if the IsDir boolean was set to true.
 type Child struct {
-	ID                    string        `xml:"id,attr"` // Manually added
-	Parent                string        `xml:"parent,attr,omitempty"`
-	IsDir                 bool          `xml:"isDir,attr"`
-	Title                 string        `xml:"title,attr"`
-	Album                 string        `xml:"album,attr,omitempty"`
-	Artist                string        `xml:"artist,attr,omitempty"`
-	Artists               []IDName      `xml:"artists,omitempty"`                 // OpenSubsonic extension
-	AlbumArtists          []IDName      `xml:"albumArtists,omitempty"`            // OpenSubsonic extension
-	DisplayArtist         string        `xml:"displayArtist,attr,omitempty"`      // OpenSubsonic extension
-	DisplayAlbumArtist    string        `xml:"displayAlbumArtist,attr,omitempty"` // OpenSubsonic extension
-	Contributors          []Contributor `xml:"contributors,omitempty"`            // OpenSubsonic extension
-	DisplayComposer       string        `xml:"displayComposer,attr,omitempty"`    // OpenSubsonic extension
-	Track                 int           `xml:"track,attr,omitempty"`
-	Year                  int           `xml:"year,attr,omitempty"`
-	Genre                 string        `xml:"genre,attr,omitempty"`
-	Genres                []IDName      `xml:"genres,omitempty"`             // OpenSubsonic extension
-	Comment               string        `xml:"comment,attr,omitempty"`       // OpenSubsonic extension
-	BPM                   int           `xml:"bpm,attr"`                     // OpenSubsonic extension
-	MusicBrainzID         string        `xml:"musicBrainzId,attr,omitempty"` // OpenSubsonic extension
-	CoverArt              string        `xml:"coverArt,attr,omitempty"`
-	Size                  int64         `xml:"size,attr,omitempty"`
-	ContentType           string        `xml:"contentType,attr,omitempty"`
-	Suffix                string        `xml:"suffix,attr,omitempty"`
-	TranscodedContentType string        `xml:"transcodedContentType,attr,omitempty"`
-	TranscodedSuffix      string        `xml:"transcodedSuffix,attr,omitempty"`
-	Duration              int           `xml:"duration,attr,omitempty"`
-	BitRate               int           `xml:"bitRate,attr,omitempty"`
-	BitDepth              int           `xml:"bitDepth,attr,omitempty"`     // OpenSubsonic extension
-	SamplingRate          int           `xml:"samplingRate,attr,omitempty"` // OpenSubsonic extension
-	ChannelCount          int           `xml:"channelCount,attr,omitempty"` // OpenSubsonic extension
-	Path                  string        `xml:"path,attr,omitempty"`
-	IsVideo               bool          `xml:"isVideo,attr,omitempty"`
-	UserRating            int           `xml:"userRating,attr,omitempty"`
-	AverageRating         float64       `xml:"averageRating,attr,omitempty"`
-	PlayCount             int64         `xml:"playCount,attr,omitempty"`
-	DiscNumber            int           `xml:"discNumber,attr,omitempty"`
-	Created               time.Time     `xml:"created,attr,omitempty"`
-	Starred               time.Time     `xml:"starred,attr,omitempty"`
-	Played                time.Time     `xml:"played,attr,omitempty"` // OpenSubsonic extension
-	AlbumID               string        `xml:"albumId,attr,omitempty"`
-	ArtistID              string        `xml:"artistId,attr,omitempty"`
-	Type                  string        `xml:"type,attr,omitempty"` // May be one of music, podcast, audiobook, video
-	BookmarkPosition      int64         `xml:"bookmarkPosition,attr,omitempty"`
-	OriginalWidth         int           `xml:"originalWidth,attr,omitempty"`
-	OriginalHeight        int           `xml:"originalHeight,attr,omitempty"`
-	ReplayGain            *ReplayGain   `xml:"replayGain,omitempty"` // OpenSubsonic extension
+	ID                    string        `xml:"id,attr"                            json:"id"`
+	Parent                string        `xml:"parent,attr,omitempty"              json:"parent,omitempty"`
+	IsDir                 bool          `xml:"isDir,attr"                         json:"isDir"`
+	Title                 string        `xml:"title,attr"                         json:"title"`
+	Album                 string        `xml:"album,attr,omitempty"               json:"album,omitempty"`
+	Artist                string        `xml:"artist,attr,omitempty"              json:"artist,omitempty"`
+	Artists               []IDName      `xml:"artists,omitempty"                  json:"artists,omitempty"`
+	AlbumArtists          []IDName      `xml:"albumArtists,omitempty"             json:"albumArtists,omitempty"`
+	DisplayArtist         string        `xml:"displayArtist,attr,omitempty"       json:"displayArtist,omitempty"`
+	DisplayAlbumArtist    string        `xml:"displayAlbumArtist,attr,omitempty"  json:"displayAlbumArtist,omitempty"`
+	Contributors          []Contributor `xml:"contributors,omitempty"             json:"contributors,omitempty"`
+	DisplayComposer       string        `xml:"displayComposer,attr,omitempty"     json:"displayComposer,omitempty"`
+	Track                 int           `xml:"track,attr,omitempty"               json:"track,omitempty"`
+	Year                  int           `xml:"year,attr,omitempty"                json:"year,omitempty"`
+	Genre                 string        `xml:"genre,attr,omitempty"               json:"genre,omitempty"`
+	Genres                []IDName      `xml:"genres,omitempty"                   json:"genres,omitempty"`
+	Comment               string        `xml:"comment,attr,omitempty"             json:"comment,omitempty"`
+	BPM                   int           `xml:"bpm,attr"                           json:"bpm,omitempty"`
+	MusicBrainzID         string        `xml:"musicBrainzId,attr,omitempty"       json:"musicBrainzId,omitempty"`
+	CoverArt              string        `xml:"coverArt,attr,omitempty"            json:"coverArt,omitempty"`
+	Size                  int64         `xml:"size,attr,omitempty"                json:"size,omitempty"`
+	ContentType           string        `xml:"contentType,attr,omitempty"         json:"contentType,omitempty"`
+	Suffix                string        `xml:"suffix,attr,omitempty"              json:"suffix,omitempty"`
+	TranscodedContentType string        `xml:"transcodedContentType,attr,omitempty" json:"transcodedContentType,omitempty"`
+	TranscodedSuffix      string        `xml:"transcodedSuffix,attr,omitempty"    json:"transcodedSuffix,omitempty"`
+	Duration              int           `xml:"duration,attr,omitempty"            json:"duration,omitempty"`
+	BitRate               int           `xml:"bitRate,attr,omitempty"             json:"bitRate,omitempty"`
+	BitDepth              int           `xml:"bitDepth,attr,omitempty"            json:"bitDepth,omitempty"`
+	SamplingRate          int           `xml:"samplingRate,attr,omitempty"        json:"samplingRate,omitempty"`
+	ChannelCount          int           `xml:"channelCount,attr,omitempty"        json:"channelCount,omitempty"`
+	Path                  string        `xml:"path,attr,omitempty"                json:"path,omitempty"`
+	IsVideo               bool          `xml:"isVideo,attr,omitempty"             json:"isVideo,omitempty"`
+	UserRating            int           `xml:"userRating,attr,omitempty"          json:"userRating,omitempty"`
+	AverageRating         float64       `xml:"averageRating,attr,omitempty"       json:"averageRating,omitempty"`
+	PlayCount             int64         `xml:"playCount,attr,omitempty"           json:"playCount,omitempty"`
+	DiscNumber            int           `xml:"discNumber,attr,omitempty"          json:"discNumber,omitempty"`
+	Created               time.Time     `xml:"created,attr,omitempty"             json:"created,omitempty"`
+	Starred               time.Time     `xml:"starred,attr,omitempty"             json:"starred,omitempty"`
+	Played                time.Time     `xml:"played,attr,omitempty"              json:"played,omitempty"`
+	AlbumID               string        `xml:"albumId,attr,omitempty"             json:"albumId,omitempty"`
+	ArtistID              string        `xml:"artistId,attr,omitempty"            json:"artistId,omitempty"`
+	Type                  string        `xml:"type,attr,omitempty"                json:"type,omitempty"`
+	BookmarkPosition      int64         `xml:"bookmarkPosition,attr,omitempty"    json:"bookmarkPosition,omitempty"`
+	OriginalWidth         int           `xml:"originalWidth,attr,omitempty"       json:"originalWidth,omitempty"`
+	OriginalHeight        int           `xml:"originalHeight,attr,omitempty"      json:"originalHeight,omitempty"`
+	ReplayGain            *ReplayGain   `xml:"replayGain,omitempty"               json:"replayGain,omitempty"`
 }
 
 func (t *Child) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
@@ -302,17 +397,51 @@ func (t *Child) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	overlay.Played = (*xsdDateTime)(&overlay.T.Played)
 	return d.DecodeElement(&overlay, &start)
 }
+func (t *Child) MarshalJSON() ([]byte, error) {
+	type T Child
+	var layout struct {
+		*T
+		Created *xsdDateTime `json:"created,omitempty"`
+		Starred *xsdDateTime `json:"starred,omitempty"`
+		Played  *xsdDateTime `json:"played,omitempty"`
+	}
+	layout.T = (*T)(t)
+	if !t.Created.IsZero() {
+		layout.Created = (*xsdDateTime)(&t.Created)
+	}
+	if !t.Starred.IsZero() {
+		layout.Starred = (*xsdDateTime)(&t.Starred)
+	}
+	if !t.Played.IsZero() {
+		layout.Played = (*xsdDateTime)(&t.Played)
+	}
+	return json.Marshal(layout)
+}
+func (t *Child) UnmarshalJSON(data []byte) error {
+	type T Child
+	var overlay struct {
+		*T
+		Created *xsdDateTime `json:"created,omitempty"`
+		Starred *xsdDateTime `json:"starred,omitempty"`
+		Played  *xsdDateTime `json:"played,omitempty"`
+	}
+	overlay.T = (*T)(t)
+	overlay.Created = (*xsdDateTime)(&overlay.T.Created)
+	overlay.Starred = (*xsdDateTime)(&overlay.T.Starred)
+	overlay.Played = (*xsdDateTime)(&overlay.T.Played)
+	return json.Unmarshal(data, &overlay)
+}
 
 // Directory is an entry in the hierarchical folder structure organization of the server database.
 type Directory struct {
-	ID            string    `xml:"id,attr"` // Manually added
-	Child         []*Child  `xml:"child,omitempty"`
-	Parent        string    `xml:"parent,attr,omitempty"`
-	Name          string    `xml:"name,attr"`
-	Starred       time.Time `xml:"starred,attr,omitempty"`
-	UserRating    int       `xml:"userRating,attr,omitempty"`
-	AverageRating float64   `xml:"averageRating,attr,omitempty"`
-	PlayCount     int64     `xml:"playCount,attr,omitempty"`
+	ID            string    `xml:"id,attr"                     json:"id"`
+	Child         []*Child  `xml:"child,omitempty"             json:"child,omitempty"`
+	Parent        string    `xml:"parent,attr,omitempty"       json:"parent,omitempty"`
+	Name          string    `xml:"name,attr"                   json:"name"`
+	Starred       time.Time `xml:"starred,attr,omitempty"      json:"starred,omitempty"`
+	UserRating    int       `xml:"userRating,attr,omitempty"   json:"userRating,omitempty"`
+	AverageRating float64   `xml:"averageRating,attr,omitempty" json:"averageRating,omitempty"`
+	PlayCount     int64     `xml:"playCount,attr,omitempty"    json:"playCount,omitempty"`
 }
 
 func (t *Directory) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
@@ -335,76 +464,98 @@ func (t *Directory) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	overlay.Starred = (*xsdDateTime)(&overlay.T.Starred)
 	return d.DecodeElement(&overlay, &start)
 }
+func (t *Directory) MarshalJSON() ([]byte, error) {
+	type T Directory
+	var layout struct {
+		*T
+		Starred *xsdDateTime `json:"starred,omitempty"`
+	}
+	layout.T = (*T)(t)
+	if !t.Starred.IsZero() {
+		layout.Starred = (*xsdDateTime)(&t.Starred)
+	}
+	return json.Marshal(layout)
+}
+func (t *Directory) UnmarshalJSON(data []byte) error {
+	type T Directory
+	var overlay struct {
+		*T
+		Starred *xsdDateTime `json:"starred,omitempty"`
+	}
+	overlay.T = (*T)(t)
+	overlay.Starred = (*xsdDateTime)(&overlay.T.Starred)
+	return json.Unmarshal(data, &overlay)
+}
 
 type Error struct {
-	Code    int    `xml:"code,attr"`
-	Message string `xml:"message,attr,omitempty"`
+	Code    int    `xml:"code,attr"           json:"code"`
+	Message string `xml:"message,attr,omitempty" json:"message,omitempty"`
 }
 
 // Genre is a style tag for a collection of songs and albums.
 type Genre struct {
-	Name       string `xml:",chardata"` // Added manually
-	SongCount  int    `xml:"songCount,attr"`
-	AlbumCount int    `xml:"albumCount,attr"`
+	Name       string `xml:",chardata"        json:"value"`
+	SongCount  int    `xml:"songCount,attr"   json:"songCount"`
+	AlbumCount int    `xml:"albumCount,attr"  json:"albumCount"`
 }
 
 type genres struct {
-	Genre []*Genre `xml:"genre,omitempty"`
+	Genre []*Genre `xml:"genre,omitempty" json:"genre,omitempty"`
 }
 
 // Index is a collection of artists that begin with the same first letter, along with that letter or category.
 type Index struct {
-	Artist []*Artist `xml:"artist,omitempty"`
-	Name   string    `xml:"name,attr"`
+	Artist []*Artist `xml:"artist,omitempty" json:"artist,omitempty"`
+	Name   string    `xml:"name,attr"        json:"name"`
 }
 
 // Index is a collection of artists by ID3 tag that begin with the same first letter, along with that letter or category.
 type IndexID3 struct {
-	Artist []*ArtistID3 `xml:"artist,omitempty"`
-	Name   string       `xml:"name,attr"`
+	Artist []*ArtistID3 `xml:"artist,omitempty" json:"artist,omitempty"`
+	Name   string       `xml:"name,attr"        json:"name"`
 }
 
 // Indexes is the full index of the database, returned by getIndex.
 // It contains some Index structs for each letter of the DB, plus Child entries for individual tracks.
 type Indexes struct {
-	Shortcut        []*Artist `xml:"shortcut,omitempty"`
-	Index           []*Index  `xml:"index,omitempty"`
-	Child           []*Child  `xml:"child,omitempty"`
-	LastModified    int64     `xml:"lastModified,attr"`
-	IgnoredArticles string    `xml:"ignoredArticles,attr"`
+	Shortcut        []*Artist `xml:"shortcut,omitempty"      json:"shortcut,omitempty"`
+	Index           []*Index  `xml:"index,omitempty"         json:"index,omitempty"`
+	Child           []*Child  `xml:"child,omitempty"         json:"child,omitempty"`
+	LastModified    int64     `xml:"lastModified,attr"       json:"lastModified"`
+	IgnoredArticles string    `xml:"ignoredArticles,attr"    json:"ignoredArticles"`
 }
 
 type InternetRadioStation struct {
-	Name        string `xml:"name,attr"`
-	StreamUrl   string `xml:"streamUrl,attr"`
-	HomePageUrl string `xml:"homePageUrl,attr,omitempty"`
+	Name        string `xml:"name,attr"                  json:"name"`
+	StreamUrl   string `xml:"streamUrl,attr"             json:"streamUrl"`
+	HomePageUrl string `xml:"homePageUrl,attr,omitempty" json:"homePageUrl,omitempty"`
 }
 
 type internetRadioStations struct {
-	InternetRadioStation []*InternetRadioStation `xml:"internetRadioStation,omitempty"`
+	InternetRadioStation []*InternetRadioStation `xml:"internetRadioStation,omitempty" json:"internetRadioStation,omitempty"`
 }
 
 type JukeboxPlaylist struct {
-	Entry        []*Child `xml:"entry,omitempty"`
-	CurrentIndex int      `xml:"currentIndex,attr"`
-	Playing      bool     `xml:"playing,attr"`
-	Gain         float32  `xml:"gain,attr"`
-	Position     int      `xml:"position,attr,omitempty"`
+	Entry        []*Child `xml:"entry,omitempty"       json:"entry,omitempty"`
+	CurrentIndex int      `xml:"currentIndex,attr"     json:"currentIndex"`
+	Playing      bool     `xml:"playing,attr"          json:"playing"`
+	Gain         float32  `xml:"gain,attr"             json:"gain"`
+	Position     int      `xml:"position,attr,omitempty" json:"position,omitempty"`
 }
 
 type JukeboxStatus struct {
-	CurrentIndex int     `xml:"currentIndex,attr"`
-	Playing      bool    `xml:"playing,attr"`
-	Gain         float32 `xml:"gain,attr"`
-	Position     int     `xml:"position,attr,omitempty"`
+	CurrentIndex int     `xml:"currentIndex,attr"     json:"currentIndex"`
+	Playing      bool    `xml:"playing,attr"          json:"playing"`
+	Gain         float32 `xml:"gain,attr"             json:"gain"`
+	Position     int     `xml:"position,attr,omitempty" json:"position,omitempty"`
 }
 
 // License contains information about the Subsonic server's license validity and contact information in the case of a trial subscription.
 type License struct {
-	Valid          bool      `xml:"valid,attr"`
-	Email          string    `xml:"email,attr,omitempty"`
-	LicenseExpires time.Time `xml:"licenseExpires,attr,omitempty"`
-	TrialExpires   time.Time `xml:"trialExpires,attr,omitempty"`
+	Valid          bool      `xml:"valid,attr"                      json:"valid"`
+	Email          string    `xml:"email,attr,omitempty"            json:"email,omitempty"`
+	LicenseExpires time.Time `xml:"licenseExpires,attr,omitempty"   json:"licenseExpires,omitempty"`
+	TrialExpires   time.Time `xml:"trialExpires,attr,omitempty"     json:"trialExpires,omitempty"`
 }
 
 func (t *License) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
@@ -431,67 +582,95 @@ func (t *License) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	overlay.TrialExpires = (*xsdDateTime)(&overlay.T.TrialExpires)
 	return d.DecodeElement(&overlay, &start)
 }
+func (t *License) MarshalJSON() ([]byte, error) {
+	type T License
+	var layout struct {
+		*T
+		LicenseExpires *xsdDateTime `json:"licenseExpires,omitempty"`
+		TrialExpires   *xsdDateTime `json:"trialExpires,omitempty"`
+	}
+	layout.T = (*T)(t)
+	if !t.LicenseExpires.IsZero() {
+		layout.LicenseExpires = (*xsdDateTime)(&t.LicenseExpires)
+	}
+	if !t.TrialExpires.IsZero() {
+		layout.TrialExpires = (*xsdDateTime)(&t.TrialExpires)
+	}
+	return json.Marshal(layout)
+}
+func (t *License) UnmarshalJSON(data []byte) error {
+	type T License
+	var overlay struct {
+		*T
+		LicenseExpires *xsdDateTime `json:"licenseExpires,omitempty"`
+		TrialExpires   *xsdDateTime `json:"trialExpires,omitempty"`
+	}
+	overlay.T = (*T)(t)
+	overlay.LicenseExpires = (*xsdDateTime)(&overlay.T.LicenseExpires)
+	overlay.TrialExpires = (*xsdDateTime)(&overlay.T.TrialExpires)
+	return json.Unmarshal(data, &overlay)
+}
 
 type Lyrics struct {
-	Artist string `xml:"artist,attr,omitempty"`
-	Title  string `xml:"title,attr,omitempty"`
-	Text   string `xml:",chardata"`
+	Artist string `xml:"artist,attr,omitempty" json:"artist,omitempty"`
+	Title  string `xml:"title,attr,omitempty"  json:"title,omitempty"`
+	Text   string `xml:",chardata"             json:"value,omitempty"`
 }
 
 // MusicFolder is a representation of a source of music files added to the server. It is identified primarily by the numeric ID.
 type MusicFolder struct {
-	ID   string `xml:"id,attr"`
-	Name string `xml:"name,attr,omitempty"`
+	ID   int    `xml:"id,attr"           json:"id"`
+	Name string `xml:"name,attr,omitempty" json:"name,omitempty"`
 }
 
 type musicFolders struct {
-	MusicFolder []*MusicFolder `xml:"musicFolder,omitempty"`
+	MusicFolder []*MusicFolder `xml:"musicFolder,omitempty" json:"musicFolder,omitempty"`
 }
 
 type newestPodcasts struct {
-	Episode []*PodcastEpisode `xml:"episode,omitempty"`
+	Episode []*PodcastEpisode `xml:"episode,omitempty" json:"episode,omitempty"`
 }
 
 type nowPlaying struct {
-	Entry []*NowPlayingEntry `xml:"entry,omitempty"`
+	Entry []*NowPlayingEntry `xml:"entry,omitempty" json:"entry,omitempty"`
 }
 
 // NowPlayingEntry is one individual stream coming from the server along with information about who was streaming it.
 type NowPlayingEntry struct {
-	Username              string    `xml:"username,attr"`
-	MinutesAgo            int       `xml:"minutesAgo,attr"`
-	PlayerID              int       `xml:"playerId,attr"`
-	PlayerName            string    `xml:"playerName,attr,omitempty"`
-	Parent                string    `xml:"parent,attr,omitempty"`
-	IsDir                 bool      `xml:"isDir,attr"`
-	Title                 string    `xml:"title,attr"`
-	Album                 string    `xml:"album,attr,omitempty"`
-	Artist                string    `xml:"artist,attr,omitempty"`
-	Track                 int       `xml:"track,attr,omitempty"`
-	Year                  int       `xml:"year,attr,omitempty"`
-	Genre                 string    `xml:"genre,attr,omitempty"`
-	CoverArt              string    `xml:"coverArt,attr,omitempty"`
-	Size                  int64     `xml:"size,attr,omitempty"`
-	ContentType           string    `xml:"contentType,attr,omitempty"`
-	Suffix                string    `xml:"suffix,attr,omitempty"`
-	TranscodedContentType string    `xml:"transcodedContentType,attr,omitempty"`
-	TranscodedSuffix      string    `xml:"transcodedSuffix,attr,omitempty"`
-	Duration              int       `xml:"duration,attr,omitempty"`
-	BitRate               int       `xml:"bitRate,attr,omitempty"`
-	Path                  string    `xml:"path,attr,omitempty"`
-	IsVideo               bool      `xml:"isVideo,attr,omitempty"`
-	UserRating            int       `xml:"userRating,attr,omitempty"`
-	AverageRating         float64   `xml:"averageRating,attr,omitempty"`
-	PlayCount             int64     `xml:"playCount,attr,omitempty"`
-	DiscNumber            int       `xml:"discNumber,attr,omitempty"`
-	Created               time.Time `xml:"created,attr,omitempty"`
-	Starred               time.Time `xml:"starred,attr,omitempty"`
-	AlbumID               string    `xml:"albumId,attr,omitempty"`
-	ArtistID              string    `xml:"artistId,attr,omitempty"`
-	Type                  string    `xml:"type,attr,omitempty"` // May be one of music, podcast, audiobook, video
-	BookmarkPosition      int64     `xml:"bookmarkPosition,attr,omitempty"`
-	OriginalWidth         int       `xml:"originalWidth,attr,omitempty"`
-	OriginalHeight        int       `xml:"originalHeight,attr,omitempty"`
+	Username              string    `xml:"username,attr"                      json:"username"`
+	MinutesAgo            int       `xml:"minutesAgo,attr"                    json:"minutesAgo"`
+	PlayerID              int       `xml:"playerId,attr"                      json:"playerId"`
+	PlayerName            string    `xml:"playerName,attr,omitempty"          json:"playerName,omitempty"`
+	Parent                string    `xml:"parent,attr,omitempty"              json:"parent,omitempty"`
+	IsDir                 bool      `xml:"isDir,attr"                         json:"isDir"`
+	Title                 string    `xml:"title,attr"                         json:"title"`
+	Album                 string    `xml:"album,attr,omitempty"               json:"album,omitempty"`
+	Artist                string    `xml:"artist,attr,omitempty"              json:"artist,omitempty"`
+	Track                 int       `xml:"track,attr,omitempty"               json:"track,omitempty"`
+	Year                  int       `xml:"year,attr,omitempty"                json:"year,omitempty"`
+	Genre                 string    `xml:"genre,attr,omitempty"               json:"genre,omitempty"`
+	CoverArt              string    `xml:"coverArt,attr,omitempty"            json:"coverArt,omitempty"`
+	Size                  int64     `xml:"size,attr,omitempty"                json:"size,omitempty"`
+	ContentType           string    `xml:"contentType,attr,omitempty"         json:"contentType,omitempty"`
+	Suffix                string    `xml:"suffix,attr,omitempty"              json:"suffix,omitempty"`
+	TranscodedContentType string    `xml:"transcodedContentType,attr,omitempty" json:"transcodedContentType,omitempty"`
+	TranscodedSuffix      string    `xml:"transcodedSuffix,attr,omitempty"    json:"transcodedSuffix,omitempty"`
+	Duration              int       `xml:"duration,attr,omitempty"            json:"duration,omitempty"`
+	BitRate               int       `xml:"bitRate,attr,omitempty"             json:"bitRate,omitempty"`
+	Path                  string    `xml:"path,attr,omitempty"                json:"path,omitempty"`
+	IsVideo               bool      `xml:"isVideo,attr,omitempty"             json:"isVideo,omitempty"`
+	UserRating            int       `xml:"userRating,attr,omitempty"          json:"userRating,omitempty"`
+	AverageRating         float64   `xml:"averageRating,attr,omitempty"       json:"averageRating,omitempty"`
+	PlayCount             int64     `xml:"playCount,attr,omitempty"           json:"playCount,omitempty"`
+	DiscNumber            int       `xml:"discNumber,attr,omitempty"          json:"discNumber,omitempty"`
+	Created               time.Time `xml:"created,attr,omitempty"             json:"created,omitempty"`
+	Starred               time.Time `xml:"starred,attr,omitempty"             json:"starred,omitempty"`
+	AlbumID               string    `xml:"albumId,attr,omitempty"             json:"albumId,omitempty"`
+	ArtistID              string    `xml:"artistId,attr,omitempty"            json:"artistId,omitempty"`
+	Type                  string    `xml:"type,attr,omitempty"                json:"type,omitempty"`
+	BookmarkPosition      int64     `xml:"bookmarkPosition,attr,omitempty"    json:"bookmarkPosition,omitempty"`
+	OriginalWidth         int       `xml:"originalWidth,attr,omitempty"       json:"originalWidth,omitempty"`
+	OriginalHeight        int       `xml:"originalHeight,attr,omitempty"      json:"originalHeight,omitempty"`
 }
 
 func (t *NowPlayingEntry) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
@@ -518,14 +697,42 @@ func (t *NowPlayingEntry) UnmarshalXML(d *xml.Decoder, start xml.StartElement) e
 	overlay.Starred = (*xsdDateTime)(&overlay.T.Starred)
 	return d.DecodeElement(&overlay, &start)
 }
+func (t *NowPlayingEntry) MarshalJSON() ([]byte, error) {
+	type T NowPlayingEntry
+	var layout struct {
+		*T
+		Created *xsdDateTime `json:"created,omitempty"`
+		Starred *xsdDateTime `json:"starred,omitempty"`
+	}
+	layout.T = (*T)(t)
+	if !t.Created.IsZero() {
+		layout.Created = (*xsdDateTime)(&t.Created)
+	}
+	if !t.Starred.IsZero() {
+		layout.Starred = (*xsdDateTime)(&t.Starred)
+	}
+	return json.Marshal(layout)
+}
+func (t *NowPlayingEntry) UnmarshalJSON(data []byte) error {
+	type T NowPlayingEntry
+	var overlay struct {
+		*T
+		Created *xsdDateTime `json:"created,omitempty"`
+		Starred *xsdDateTime `json:"starred,omitempty"`
+	}
+	overlay.T = (*T)(t)
+	overlay.Created = (*xsdDateTime)(&overlay.T.Created)
+	overlay.Starred = (*xsdDateTime)(&overlay.T.Starred)
+	return json.Unmarshal(data, &overlay)
+}
 
 type PlayQueue struct {
-	Entries   []*Child  `xml:"entry,omitempty"`
-	Current   string    `xml:"current,attr,omitempty"`
-	Position  int64     `xml:"position,attr,omitempty"`
-	Username  string    `xml:"username,attr"`
-	Changed   time.Time `xml:"changed,attr"`
-	ChangedBy string    `xml:"changedBy,attr"`
+	Entries   []*Child  `xml:"entry,omitempty"         json:"entry,omitempty"`
+	Current   string    `xml:"current,attr,omitempty"  json:"current,omitempty"`
+	Position  int64     `xml:"position,attr,omitempty" json:"position,omitempty"`
+	Username  string    `xml:"username,attr"           json:"username"`
+	Changed   time.Time `xml:"changed,attr"            json:"changed"`
+	ChangedBy string    `xml:"changedBy,attr"          json:"changedBy"`
 }
 
 func (t *PlayQueue) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
@@ -548,21 +755,41 @@ func (t *PlayQueue) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	overlay.Changed = (*xsdDateTime)(&overlay.T.Changed)
 	return d.DecodeElement(&overlay, &start)
 }
+func (t *PlayQueue) MarshalJSON() ([]byte, error) {
+	type T PlayQueue
+	var layout struct {
+		*T
+		Changed *xsdDateTime `json:"changed"`
+	}
+	layout.T = (*T)(t)
+	layout.Changed = (*xsdDateTime)(&t.Changed)
+	return json.Marshal(layout)
+}
+func (t *PlayQueue) UnmarshalJSON(data []byte) error {
+	type T PlayQueue
+	var overlay struct {
+		*T
+		Changed *xsdDateTime `json:"changed"`
+	}
+	overlay.T = (*T)(t)
+	overlay.Changed = (*xsdDateTime)(&overlay.T.Changed)
+	return json.Unmarshal(data, &overlay)
+}
 
 // Playlist is a collection of songs with metadata like a name, comment, and information about the total duration of the playlist.
 type Playlist struct {
-	ID          string    `xml:"id,attr"`         // Added manually
-	Entry       []*Child  `xml:"entry,omitempty"` // Merged from PlaylistWithSongs
-	AllowedUser []string  `xml:"allowedUser,omitempty"`
-	Name        string    `xml:"name,attr"`
-	Comment     string    `xml:"comment,attr,omitempty"`
-	Owner       string    `xml:"owner,attr,omitempty"`
-	Public      bool      `xml:"public,attr,omitempty"`
-	SongCount   int       `xml:"songCount,attr"`
-	Duration    int       `xml:"duration,attr"`
-	Created     time.Time `xml:"created,attr"`
-	Changed     time.Time `xml:"changed,attr,omitempty"`
-	CoverArt    string    `xml:"coverArt,attr,omitempty"`
+	ID          string    `xml:"id,attr"              json:"id"`
+	Entry       []*Child  `xml:"entry,omitempty"      json:"entry,omitempty"`
+	AllowedUser []string  `xml:"allowedUser,omitempty" json:"allowedUser,omitempty"`
+	Name        string    `xml:"name,attr"            json:"name"`
+	Comment     string    `xml:"comment,attr,omitempty" json:"comment,omitempty"`
+	Owner       string    `xml:"owner,attr,omitempty"  json:"owner,omitempty"`
+	Public      bool      `xml:"public,attr,omitempty" json:"public,omitempty"`
+	SongCount   int       `xml:"songCount,attr"       json:"songCount"`
+	Duration    int       `xml:"duration,attr"        json:"duration"`
+	Created     time.Time `xml:"created,attr"         json:"created"`
+	Changed     time.Time `xml:"changed,attr,omitempty" json:"changed,omitempty"`
+	CoverArt    string    `xml:"coverArt,attr,omitempty" json:"coverArt,omitempty"`
 }
 
 func (t *Playlist) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
@@ -589,58 +816,84 @@ func (t *Playlist) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	overlay.Changed = (*xsdDateTime)(&overlay.T.Changed)
 	return d.DecodeElement(&overlay, &start)
 }
+func (t *Playlist) MarshalJSON() ([]byte, error) {
+	type T Playlist
+	var layout struct {
+		*T
+		Created *xsdDateTime `json:"created"`
+		Changed *xsdDateTime `json:"changed,omitempty"`
+	}
+	layout.T = (*T)(t)
+	layout.Created = (*xsdDateTime)(&t.Created)
+	if !t.Changed.IsZero() {
+		layout.Changed = (*xsdDateTime)(&t.Changed)
+	}
+	return json.Marshal(layout)
+}
+func (t *Playlist) UnmarshalJSON(data []byte) error {
+	type T Playlist
+	var overlay struct {
+		*T
+		Created *xsdDateTime `json:"created"`
+		Changed *xsdDateTime `json:"changed,omitempty"`
+	}
+	overlay.T = (*T)(t)
+	overlay.Created = (*xsdDateTime)(&overlay.T.Created)
+	overlay.Changed = (*xsdDateTime)(&overlay.T.Changed)
+	return json.Unmarshal(data, &overlay)
+}
 
 type playlists struct {
-	Playlist []*Playlist `xml:"playlist,omitempty"`
+	Playlist []*Playlist `xml:"playlist,omitempty" json:"playlist,omitempty"`
 }
 
 type PodcastChannel struct {
-	Episode          []*PodcastEpisode `xml:"episode,omitempty"`
-	Url              string            `xml:"url,attr"`
-	Title            string            `xml:"title,attr,omitempty"`
-	Description      string            `xml:"description,attr,omitempty"`
-	CoverArt         string            `xml:"coverArt,attr,omitempty"`
-	OriginalImageUrl string            `xml:"originalImageUrl,attr,omitempty"`
-	Status           string            `xml:"status,attr"` // May be one of new, downloading, completed, error, deleted, skipped
-	ErrorMessage     string            `xml:"errorMessage,attr,omitempty"`
+	Episode          []*PodcastEpisode `xml:"episode,omitempty"              json:"episode,omitempty"`
+	Url              string            `xml:"url,attr"                       json:"url"`
+	Title            string            `xml:"title,attr,omitempty"           json:"title,omitempty"`
+	Description      string            `xml:"description,attr,omitempty"     json:"description,omitempty"`
+	CoverArt         string            `xml:"coverArt,attr,omitempty"        json:"coverArt,omitempty"`
+	OriginalImageUrl string            `xml:"originalImageUrl,attr,omitempty" json:"originalImageUrl,omitempty"`
+	Status           string            `xml:"status,attr"                    json:"status"`
+	ErrorMessage     string            `xml:"errorMessage,attr,omitempty"    json:"errorMessage,omitempty"`
 }
 
 type PodcastEpisode struct {
-	StreamID              string    `xml:"streamId,attr,omitempty"`
-	ChannelID             string    `xml:"channelId,attr"`
-	Description           string    `xml:"description,attr,omitempty"`
-	Status                string    `xml:"status,attr"` // May be one of new, downloading, completed, error, deleted, skipped
-	PublishDate           time.Time `xml:"publishDate,attr,omitempty"`
-	Parent                string    `xml:"parent,attr,omitempty"`
-	IsDir                 bool      `xml:"isDir,attr"`
-	Title                 string    `xml:"title,attr"`
-	Album                 string    `xml:"album,attr,omitempty"`
-	Artist                string    `xml:"artist,attr,omitempty"`
-	Track                 int       `xml:"track,attr,omitempty"`
-	Year                  int       `xml:"year,attr,omitempty"`
-	Genre                 string    `xml:"genre,attr,omitempty"`
-	CoverArt              string    `xml:"coverArt,attr,omitempty"`
-	Size                  int64     `xml:"size,attr,omitempty"`
-	ContentType           string    `xml:"contentType,attr,omitempty"`
-	Suffix                string    `xml:"suffix,attr,omitempty"`
-	TranscodedContentType string    `xml:"transcodedContentType,attr,omitempty"`
-	TranscodedSuffix      string    `xml:"transcodedSuffix,attr,omitempty"`
-	Duration              int       `xml:"duration,attr,omitempty"`
-	BitRate               int       `xml:"bitRate,attr,omitempty"`
-	Path                  string    `xml:"path,attr,omitempty"`
-	IsVideo               bool      `xml:"isVideo,attr,omitempty"`
-	UserRating            int       `xml:"userRating,attr,omitempty"`
-	AverageRating         float64   `xml:"averageRating,attr,omitempty"`
-	PlayCount             int64     `xml:"playCount,attr,omitempty"`
-	DiscNumber            int       `xml:"discNumber,attr,omitempty"`
-	Created               time.Time `xml:"created,attr,omitempty"`
-	Starred               time.Time `xml:"starred,attr,omitempty"`
-	AlbumID               string    `xml:"albumId,attr,omitempty"`
-	ArtistID              string    `xml:"artistId,attr,omitempty"`
-	Type                  string    `xml:"type,attr,omitempty"` // May be one of music, podcast, audiobook, video
-	BookmarkPosition      int64     `xml:"bookmarkPosition,attr,omitempty"`
-	OriginalWidth         int       `xml:"originalWidth,attr,omitempty"`
-	OriginalHeight        int       `xml:"originalHeight,attr,omitempty"`
+	StreamID              string    `xml:"streamId,attr,omitempty"            json:"streamId,omitempty"`
+	ChannelID             string    `xml:"channelId,attr"                     json:"channelId"`
+	Description           string    `xml:"description,attr,omitempty"         json:"description,omitempty"`
+	Status                string    `xml:"status,attr"                        json:"status"`
+	PublishDate           time.Time `xml:"publishDate,attr,omitempty"         json:"publishDate,omitempty"`
+	Parent                string    `xml:"parent,attr,omitempty"              json:"parent,omitempty"`
+	IsDir                 bool      `xml:"isDir,attr"                         json:"isDir"`
+	Title                 string    `xml:"title,attr"                         json:"title"`
+	Album                 string    `xml:"album,attr,omitempty"               json:"album,omitempty"`
+	Artist                string    `xml:"artist,attr,omitempty"              json:"artist,omitempty"`
+	Track                 int       `xml:"track,attr,omitempty"               json:"track,omitempty"`
+	Year                  int       `xml:"year,attr,omitempty"                json:"year,omitempty"`
+	Genre                 string    `xml:"genre,attr,omitempty"               json:"genre,omitempty"`
+	CoverArt              string    `xml:"coverArt,attr,omitempty"            json:"coverArt,omitempty"`
+	Size                  int64     `xml:"size,attr,omitempty"                json:"size,omitempty"`
+	ContentType           string    `xml:"contentType,attr,omitempty"         json:"contentType,omitempty"`
+	Suffix                string    `xml:"suffix,attr,omitempty"              json:"suffix,omitempty"`
+	TranscodedContentType string    `xml:"transcodedContentType,attr,omitempty" json:"transcodedContentType,omitempty"`
+	TranscodedSuffix      string    `xml:"transcodedSuffix,attr,omitempty"    json:"transcodedSuffix,omitempty"`
+	Duration              int       `xml:"duration,attr,omitempty"            json:"duration,omitempty"`
+	BitRate               int       `xml:"bitRate,attr,omitempty"             json:"bitRate,omitempty"`
+	Path                  string    `xml:"path,attr,omitempty"                json:"path,omitempty"`
+	IsVideo               bool      `xml:"isVideo,attr,omitempty"             json:"isVideo,omitempty"`
+	UserRating            int       `xml:"userRating,attr,omitempty"          json:"userRating,omitempty"`
+	AverageRating         float64   `xml:"averageRating,attr,omitempty"       json:"averageRating,omitempty"`
+	PlayCount             int64     `xml:"playCount,attr,omitempty"           json:"playCount,omitempty"`
+	DiscNumber            int       `xml:"discNumber,attr,omitempty"          json:"discNumber,omitempty"`
+	Created               time.Time `xml:"created,attr,omitempty"             json:"created,omitempty"`
+	Starred               time.Time `xml:"starred,attr,omitempty"             json:"starred,omitempty"`
+	AlbumID               string    `xml:"albumId,attr,omitempty"             json:"albumId,omitempty"`
+	ArtistID              string    `xml:"artistId,attr,omitempty"            json:"artistId,omitempty"`
+	Type                  string    `xml:"type,attr,omitempty"                json:"type,omitempty"`
+	BookmarkPosition      int64     `xml:"bookmarkPosition,attr,omitempty"    json:"bookmarkPosition,omitempty"`
+	OriginalWidth         int       `xml:"originalWidth,attr,omitempty"       json:"originalWidth,omitempty"`
+	OriginalHeight        int       `xml:"originalHeight,attr,omitempty"      json:"originalHeight,omitempty"`
 }
 
 func (t *PodcastEpisode) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
@@ -671,90 +924,124 @@ func (t *PodcastEpisode) UnmarshalXML(d *xml.Decoder, start xml.StartElement) er
 	overlay.Starred = (*xsdDateTime)(&overlay.T.Starred)
 	return d.DecodeElement(&overlay, &start)
 }
+func (t *PodcastEpisode) MarshalJSON() ([]byte, error) {
+	type T PodcastEpisode
+	var layout struct {
+		*T
+		PublishDate *xsdDateTime `json:"publishDate,omitempty"`
+		Created     *xsdDateTime `json:"created,omitempty"`
+		Starred     *xsdDateTime `json:"starred,omitempty"`
+	}
+	layout.T = (*T)(t)
+	if !t.PublishDate.IsZero() {
+		layout.PublishDate = (*xsdDateTime)(&t.PublishDate)
+	}
+	if !t.Created.IsZero() {
+		layout.Created = (*xsdDateTime)(&t.Created)
+	}
+	if !t.Starred.IsZero() {
+		layout.Starred = (*xsdDateTime)(&t.Starred)
+	}
+	return json.Marshal(layout)
+}
+func (t *PodcastEpisode) UnmarshalJSON(data []byte) error {
+	type T PodcastEpisode
+	var overlay struct {
+		*T
+		PublishDate *xsdDateTime `json:"publishDate,omitempty"`
+		Created     *xsdDateTime `json:"created,omitempty"`
+		Starred     *xsdDateTime `json:"starred,omitempty"`
+	}
+	overlay.T = (*T)(t)
+	overlay.PublishDate = (*xsdDateTime)(&overlay.T.PublishDate)
+	overlay.Created = (*xsdDateTime)(&overlay.T.Created)
+	overlay.Starred = (*xsdDateTime)(&overlay.T.Starred)
+	return json.Unmarshal(data, &overlay)
+}
 
 type podcasts struct {
-	Channel []*PodcastChannel `xml:"channel,omitempty"`
+	Channel []*PodcastChannel `xml:"channel,omitempty" json:"channel,omitempty"`
 }
 
 // Response is the main target for unmarshalling data from the API - everything within the "subsonic-response" key
 type Response struct {
-	License                *License                 `xml:"license"`
-	MusicFolders           *musicFolders            `xml:"musicFolders"`
-	Indexes                *Indexes                 `xml:"indexes"`
-	Directory              *Directory               `xml:"directory"`
-	Genres                 *genres                  `xml:"genres"`
-	Artists                *ArtistsID3              `xml:"artists"`
-	Artist                 *ArtistID3               `xml:"artist"`
-	Album                  *AlbumID3                `xml:"album"`
-	Song                   *Child                   `xml:"song"`
-	NowPlaying             *nowPlaying              `xml:"nowPlaying"`
-	SearchResult2          *SearchResult2           `xml:"searchResult2"`
-	SearchResult3          *SearchResult3           `xml:"searchResult3"`
-	Playlists              *playlists               `xml:"playlists"`
-	Playlist               *Playlist                `xml:"playlist"`
-	JukeboxStatus          *JukeboxStatus           `xml:"jukeboxStatus"`
-	JukeboxPlaylist        *JukeboxPlaylist         `xml:"jukeboxPlaylist"`
-	Users                  *users                   `xml:"users"`
-	User                   *User                    `xml:"user"`
-	ChatMessages           *chatMessages            `xml:"chatMessages"`
-	AlbumList              *albumList               `xml:"albumList"`
-	AlbumList2             *albumList2              `xml:"albumList2"`
-	RandomSongs            *songs                   `xml:"randomSongs"`
-	SongsByGenre           *songs                   `xml:"songsByGenre"`
-	Lyrics                 *Lyrics                  `xml:"lyrics"`
-	Podcasts               *podcasts                `xml:"podcasts"`
-	NewestPodcasts         *newestPodcasts          `xml:"newestPodcasts"`
-	InternetRadioStations  *internetRadioStations   `xml:"internetRadioStations"`
-	Bookmarks              *bookmarks               `xml:"bookmarks"`
-	PlayQueue              *PlayQueue               `xml:"playQueue"`
-	PlayQueueByIndex       *PlayQueueByIndex        `xml:"playQueueByIndex"` // OpenSubsonic extension indexBasedQueue
-	Shares                 *shares                  `xml:"shares"`
-	Starred                *Starred                 `xml:"starred"`
-	Starred2               *Starred2                `xml:"starred2"`
-	AlbumInfo              *AlbumInfo               `xml:"albumInfo"`
-	ArtistInfo             *ArtistInfo              `xml:"artistInfo"`
-	ArtistInfo2            *ArtistInfo2             `xml:"artistInfo2"`
-	SimilarSongs           *similarSongs            `xml:"similarSongs"`
-	SimilarSongs2          *similarSongs2           `xml:"similarSongs2"`
-	TopSongs               *topSongs                `xml:"topSongs"`
-	ScanStatus             *ScanStatus              `xml:"scanStatus"`
-	Error                  *Error                   `xml:"error"`
-	Status                 string                   `xml:"status,attr"`  // May be one of ok, failed
-	Version                string                   `xml:"version,attr"` // Must match the pattern \d+\.\d+\.\d+
-	OpenSubsonic           bool                     `xml:"openSubsonic,attr"`
-	OpenSubsonicExtensions []*OpenSubsonicExtension `xml:"openSubsonicExtensions"`
-	LyricsList             *LyricsList              `xml:"lyricsList"`
+	License                *License                 `xml:"license"               json:"license,omitempty"`
+	MusicFolders           *musicFolders            `xml:"musicFolders"          json:"musicFolders,omitempty"`
+	Indexes                *Indexes                 `xml:"indexes"               json:"indexes,omitempty"`
+	Directory              *Directory               `xml:"directory"             json:"directory,omitempty"`
+	Genres                 *genres                  `xml:"genres"                json:"genres,omitempty"`
+	Artists                *ArtistsID3              `xml:"artists"               json:"artists,omitempty"`
+	Artist                 *ArtistID3               `xml:"artist"                json:"artist,omitempty"`
+	Album                  *AlbumID3                `xml:"album"                 json:"album,omitempty"`
+	Song                   *Child                   `xml:"song"                  json:"song,omitempty"`
+	NowPlaying             *nowPlaying              `xml:"nowPlaying"            json:"nowPlaying,omitempty"`
+	SearchResult2          *SearchResult2           `xml:"searchResult2"         json:"searchResult2,omitempty"`
+	SearchResult3          *SearchResult3           `xml:"searchResult3"         json:"searchResult3,omitempty"`
+	Playlists              *playlists               `xml:"playlists"             json:"playlists,omitempty"`
+	Playlist               *Playlist                `xml:"playlist"              json:"playlist,omitempty"`
+	JukeboxStatus          *JukeboxStatus           `xml:"jukeboxStatus"         json:"jukeboxStatus,omitempty"`
+	JukeboxPlaylist        *JukeboxPlaylist         `xml:"jukeboxPlaylist"       json:"jukeboxPlaylist,omitempty"`
+	Users                  *users                   `xml:"users"                 json:"users,omitempty"`
+	User                   *User                    `xml:"user"                  json:"user,omitempty"`
+	ChatMessages           *chatMessages            `xml:"chatMessages"          json:"chatMessages,omitempty"`
+	AlbumList              *albumList               `xml:"albumList"             json:"albumList,omitempty"`
+	AlbumList2             *albumList2              `xml:"albumList2"            json:"albumList2,omitempty"`
+	RandomSongs            *songs                   `xml:"randomSongs"           json:"randomSongs,omitempty"`
+	SongsByGenre           *songs                   `xml:"songsByGenre"          json:"songsByGenre,omitempty"`
+	Lyrics                 *Lyrics                  `xml:"lyrics"                json:"lyrics,omitempty"`
+	Podcasts               *podcasts                `xml:"podcasts"              json:"podcasts,omitempty"`
+	NewestPodcasts         *newestPodcasts          `xml:"newestPodcasts"        json:"newestPodcasts,omitempty"`
+	InternetRadioStations  *internetRadioStations   `xml:"internetRadioStations" json:"internetRadioStations,omitempty"`
+	Bookmarks              *bookmarks               `xml:"bookmarks"             json:"bookmarks,omitempty"`
+	PlayQueue              *PlayQueue               `xml:"playQueue"             json:"playQueue,omitempty"`
+	PlayQueueByIndex       *PlayQueueByIndex        `xml:"playQueueByIndex"      json:"playQueueByIndex,omitempty"`
+	Shares                 *shares                  `xml:"shares"                json:"shares,omitempty"`
+	Starred                *Starred                 `xml:"starred"               json:"starred,omitempty"`
+	Starred2               *Starred2                `xml:"starred2"              json:"starred2,omitempty"`
+	AlbumInfo              *AlbumInfo               `xml:"albumInfo"             json:"albumInfo,omitempty"`
+	ArtistInfo             *ArtistInfo              `xml:"artistInfo"            json:"artistInfo,omitempty"`
+	ArtistInfo2            *ArtistInfo2             `xml:"artistInfo2"           json:"artistInfo2,omitempty"`
+	SimilarSongs           *similarSongs            `xml:"similarSongs"          json:"similarSongs,omitempty"`
+	SimilarSongs2          *similarSongs2           `xml:"similarSongs2"         json:"similarSongs2,omitempty"`
+	TopSongs               *topSongs                `xml:"topSongs"              json:"topSongs,omitempty"`
+	ScanStatus             *ScanStatus              `xml:"scanStatus"            json:"scanStatus,omitempty"`
+	Error                  *Error                   `xml:"error"                 json:"error,omitempty"`
+	Status                 string                   `xml:"status,attr"           json:"status"`
+	Version                string                   `xml:"version,attr"          json:"version"`
+	OpenSubsonic           bool                     `xml:"openSubsonic,attr"     json:"openSubsonic,omitempty"`
+	OpenSubsonicExtensions []*OpenSubsonicExtension `xml:"openSubsonicExtensions" json:"openSubsonicExtensions,omitempty"`
+	LyricsList             *LyricsList              `xml:"lyricsList"            json:"lyricsList,omitempty"`
 }
 
 type ScanStatus struct {
-	Scanning bool  `xml:"scanning,attr"`
-	Count    int64 `xml:"count,attr,omitempty"`
+	Scanning bool  `xml:"scanning,attr"       json:"scanning"`
+	Count    int64 `xml:"count,attr,omitempty" json:"count,omitempty"`
 }
 
 // SearchResult2 is a collection of songs, albums, and artists related to a query.
 type SearchResult2 struct {
-	Artist []*Artist `xml:"artist,omitempty"`
-	Album  []*Child  `xml:"album,omitempty"`
-	Song   []*Child  `xml:"song,omitempty"`
+	Artist []*Artist `xml:"artist,omitempty" json:"artist,omitempty"`
+	Album  []*Child  `xml:"album,omitempty"  json:"album,omitempty"`
+	Song   []*Child  `xml:"song,omitempty"   json:"song,omitempty"`
 }
 
 // SearchResult3 is a collection of songs, albums, and artists related to a query.
 type SearchResult3 struct {
-	Artist []*ArtistID3 `xml:"artist,omitempty"`
-	Album  []*AlbumID3  `xml:"album,omitempty"`
-	Song   []*Child     `xml:"song,omitempty"`
+	Artist []*ArtistID3 `xml:"artist,omitempty" json:"artist,omitempty"`
+	Album  []*AlbumID3  `xml:"album,omitempty"  json:"album,omitempty"`
+	Song   []*Child     `xml:"song,omitempty"   json:"song,omitempty"`
 }
 
 type Share struct {
-	ID          string    `xml:"id,attr"`
-	Entry       []*Child  `xml:"entry,omitempty"`
-	Url         string    `xml:"url,attr"`
-	Description string    `xml:"description,attr,omitempty"`
-	Username    string    `xml:"username,attr"`
-	Created     time.Time `xml:"created,attr"`
-	Expires     time.Time `xml:"expires,attr,omitempty"`
-	LastVisited time.Time `xml:"lastVisited,attr,omitempty"`
-	VisitCount  int       `xml:"visitCount,attr"`
+	ID          string    `xml:"id,attr"                    json:"id"`
+	Entry       []*Child  `xml:"entry,omitempty"            json:"entry,omitempty"`
+	Url         string    `xml:"url,attr"                   json:"url"`
+	Description string    `xml:"description,attr,omitempty" json:"description,omitempty"`
+	Username    string    `xml:"username,attr"              json:"username"`
+	Created     time.Time `xml:"created,attr"               json:"created"`
+	Expires     time.Time `xml:"expires,attr,omitempty"     json:"expires,omitempty"`
+	LastVisited time.Time `xml:"lastVisited,attr,omitempty" json:"lastVisited,omitempty"`
+	VisitCount  int       `xml:"visitCount,attr"            json:"visitCount"`
 }
 
 func (t *Share) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
@@ -785,60 +1072,92 @@ func (t *Share) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	overlay.LastVisited = (*xsdDateTime)(&overlay.T.LastVisited)
 	return d.DecodeElement(&overlay, &start)
 }
+func (t *Share) MarshalJSON() ([]byte, error) {
+	type T Share
+	var layout struct {
+		*T
+		Created     *xsdDateTime `json:"created"`
+		Expires     *xsdDateTime `json:"expires,omitempty"`
+		LastVisited *xsdDateTime `json:"lastVisited,omitempty"`
+	}
+	layout.T = (*T)(t)
+	layout.Created = (*xsdDateTime)(&t.Created)
+	if !t.Expires.IsZero() {
+		layout.Expires = (*xsdDateTime)(&t.Expires)
+	}
+	if !t.LastVisited.IsZero() {
+		layout.LastVisited = (*xsdDateTime)(&t.LastVisited)
+	}
+	return json.Marshal(layout)
+}
+func (t *Share) UnmarshalJSON(data []byte) error {
+	type T Share
+	var overlay struct {
+		*T
+		Created     *xsdDateTime `json:"created"`
+		Expires     *xsdDateTime `json:"expires,omitempty"`
+		LastVisited *xsdDateTime `json:"lastVisited,omitempty"`
+	}
+	overlay.T = (*T)(t)
+	overlay.Created = (*xsdDateTime)(&overlay.T.Created)
+	overlay.Expires = (*xsdDateTime)(&overlay.T.Expires)
+	overlay.LastVisited = (*xsdDateTime)(&overlay.T.LastVisited)
+	return json.Unmarshal(data, &overlay)
+}
 
 type shares struct {
-	Share []*Share `xml:"share,omitempty"`
+	Share []*Share `xml:"share,omitempty" json:"share,omitempty"`
 }
 
 type similarSongs struct {
-	Song []*Child `xml:"song,omitempty"`
+	Song []*Child `xml:"song,omitempty" json:"song,omitempty"`
 }
 
 type similarSongs2 struct {
-	Song []*Child `xml:"song,omitempty"`
+	Song []*Child `xml:"song,omitempty" json:"song,omitempty"`
 }
 
 type songs struct {
-	Song []*Child `xml:"song,omitempty"`
+	Song []*Child `xml:"song,omitempty" json:"song,omitempty"`
 }
 
 // Starred is a collection of songs, albums, and artists annotated by a user as starred.
 type Starred struct {
-	Artist []*Artist `xml:"artist,omitempty"`
-	Album  []*Child  `xml:"album,omitempty"`
-	Song   []*Child  `xml:"song,omitempty"`
+	Artist []*Artist `xml:"artist,omitempty" json:"artist,omitempty"`
+	Album  []*Child  `xml:"album,omitempty"  json:"album,omitempty"`
+	Song   []*Child  `xml:"song,omitempty"   json:"song,omitempty"`
 }
 
 // Starred2 is a collection of songs, albums, and artists organized by ID3 tags annotated by a user as starred.
 type Starred2 struct {
-	Artist []*ArtistID3 `xml:"artist,omitempty"`
-	Album  []*AlbumID3  `xml:"album,omitempty"`
-	Song   []*Child     `xml:"song,omitempty"`
+	Artist []*ArtistID3 `xml:"artist,omitempty" json:"artist,omitempty"`
+	Album  []*AlbumID3  `xml:"album,omitempty"  json:"album,omitempty"`
+	Song   []*Child     `xml:"song,omitempty"   json:"song,omitempty"`
 }
 
 type topSongs struct {
-	Song []*Child `xml:"song,omitempty"`
+	Song []*Child `xml:"song,omitempty" json:"song,omitempty"`
 }
 
 type User struct {
-	Folder              []int     `xml:"folder,omitempty"`
-	Username            string    `xml:"username,attr"`
-	Email               string    `xml:"email,attr,omitempty"`
-	ScrobblingEnabled   bool      `xml:"scrobblingEnabled,attr"`
-	MaxBitRate          int       `xml:"maxBitRate,attr,omitempty"`
-	AdminRole           bool      `xml:"adminRole,attr"`
-	SettingsRole        bool      `xml:"settingsRole,attr"`
-	DownloadRole        bool      `xml:"downloadRole,attr"`
-	UploadRole          bool      `xml:"uploadRole,attr"`
-	PlaylistRole        bool      `xml:"playlistRole,attr"`
-	CoverArtRole        bool      `xml:"coverArtRole,attr"`
-	CommentRole         bool      `xml:"commentRole,attr"`
-	PodcastRole         bool      `xml:"podcastRole,attr"`
-	StreamRole          bool      `xml:"streamRole,attr"`
-	JukeboxRole         bool      `xml:"jukeboxRole,attr"`
-	ShareRole           bool      `xml:"shareRole,attr"`
-	VideoConversionRole bool      `xml:"videoConversionRole,attr"`
-	AvatarLastChanged   time.Time `xml:"avatarLastChanged,attr,omitempty"`
+	Folder              []int     `xml:"folder,omitempty"              json:"folder,omitempty"`
+	Username            string    `xml:"username,attr"                 json:"username"`
+	Email               string    `xml:"email,attr,omitempty"          json:"email,omitempty"`
+	ScrobblingEnabled   bool      `xml:"scrobblingEnabled,attr"        json:"scrobblingEnabled"`
+	MaxBitRate          int       `xml:"maxBitRate,attr,omitempty"     json:"maxBitRate,omitempty"`
+	AdminRole           bool      `xml:"adminRole,attr"                json:"adminRole"`
+	SettingsRole        bool      `xml:"settingsRole,attr"             json:"settingsRole"`
+	DownloadRole        bool      `xml:"downloadRole,attr"             json:"downloadRole"`
+	UploadRole          bool      `xml:"uploadRole,attr"               json:"uploadRole"`
+	PlaylistRole        bool      `xml:"playlistRole,attr"             json:"playlistRole"`
+	CoverArtRole        bool      `xml:"coverArtRole,attr"             json:"coverArtRole"`
+	CommentRole         bool      `xml:"commentRole,attr"              json:"commentRole"`
+	PodcastRole         bool      `xml:"podcastRole,attr"              json:"podcastRole"`
+	StreamRole          bool      `xml:"streamRole,attr"               json:"streamRole"`
+	JukeboxRole         bool      `xml:"jukeboxRole,attr"              json:"jukeboxRole"`
+	ShareRole           bool      `xml:"shareRole,attr"                json:"shareRole"`
+	VideoConversionRole bool      `xml:"videoConversionRole,attr"      json:"videoConversionRole"`
+	AvatarLastChanged   time.Time `xml:"avatarLastChanged,attr,omitempty" json:"avatarLastChanged,omitempty"`
 }
 
 func (t *User) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
@@ -861,9 +1180,31 @@ func (t *User) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	overlay.AvatarLastChanged = (*xsdDateTime)(&overlay.T.AvatarLastChanged)
 	return d.DecodeElement(&overlay, &start)
 }
+func (t *User) MarshalJSON() ([]byte, error) {
+	type T User
+	var layout struct {
+		*T
+		AvatarLastChanged *xsdDateTime `json:"avatarLastChanged,omitempty"`
+	}
+	layout.T = (*T)(t)
+	if !t.AvatarLastChanged.IsZero() {
+		layout.AvatarLastChanged = (*xsdDateTime)(&t.AvatarLastChanged)
+	}
+	return json.Marshal(layout)
+}
+func (t *User) UnmarshalJSON(data []byte) error {
+	type T User
+	var overlay struct {
+		*T
+		AvatarLastChanged *xsdDateTime `json:"avatarLastChanged,omitempty"`
+	}
+	overlay.T = (*T)(t)
+	overlay.AvatarLastChanged = (*xsdDateTime)(&overlay.T.AvatarLastChanged)
+	return json.Unmarshal(data, &overlay)
+}
 
 type users struct {
-	User []*User `xml:"user,omitempty"`
+	User []*User `xml:"user,omitempty" json:"user,omitempty"`
 }
 
 type xsdDateTime time.Time

--- a/subsonic/models_opensubsonic.go
+++ b/subsonic/models_opensubsonic.go
@@ -37,7 +37,7 @@ type StructuredLyrics struct {
 type LyricLine struct {
 	Start int    `xml:"start,attr"  json:"start"`
 	Text  string `xml:",chardata"   json:"value,omitempty"`
-	// Navidrome 0.51.0 - 0.52.5 incorrecty returns the lyric line text here
+	// Navidrome 0.51.0 - 0.52.5 incorrectly returns the lyric line text here
 	// This will be removed in the future
 	Value string `xml:"value" json:"-"`
 }

--- a/subsonic/models_opensubsonic.go
+++ b/subsonic/models_opensubsonic.go
@@ -1,67 +1,92 @@
 package subsonic
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // Used for any entity where only a name and an ID appear.
 // Eg. OpenSubsonic artists list for an album.
 type IDName struct {
-	ID   string `xml:"id,attr,omitempty"`
-	Name string `xml:"name,attr,omitempty"`
+	ID   string `xml:"id,attr,omitempty"   json:"id,omitempty"`
+	Name string `xml:"name,attr,omitempty" json:"name,omitempty"`
 }
 
 type OpenSubsonicExtension struct {
-	Name     string `xml:"name,attr"`
-	Versions []int  `xml:"versions"`
+	Name     string `xml:"name,attr"  json:"name"`
+	Versions []int  `xml:"versions"   json:"versions"`
 }
 
 type openSubsonicExtensions struct {
-	OpenSubsonicExtensions []*OpenSubsonicExtension `xml:"openSubsonicExtension,omitempty"`
+	OpenSubsonicExtensions []*OpenSubsonicExtension `xml:"openSubsonicExtension,omitempty" json:"openSubsonicExtension,omitempty"`
 }
 
 type LyricsList struct {
-	StructuredLyrics []*StructuredLyrics `xml:"structuredLyrics,omitempty"`
+	StructuredLyrics []*StructuredLyrics `xml:"structuredLyrics,omitempty" json:"structuredLyrics,omitempty"`
 }
 
 type StructuredLyrics struct {
-	DisplayArtist string      `xml:"displayArtist,attr"`
-	DisplayTitle  string      `xml:"displayTitle,attr"`
-	Lang          string      `xml:"lang,attr"`
-	Offset        int         `xml:"offset,attr"`
-	Synced        bool        `xml:"synced,attr"`
-	Lines         []LyricLine `xml:"line,omitempty"`
+	DisplayArtist string      `xml:"displayArtist,attr" json:"displayArtist"`
+	DisplayTitle  string      `xml:"displayTitle,attr"  json:"displayTitle"`
+	Lang          string      `xml:"lang,attr"          json:"lang"`
+	Offset        int         `xml:"offset,attr"        json:"offset"`
+	Synced        bool        `xml:"synced,attr"        json:"synced"`
+	Lines         []LyricLine `xml:"line,omitempty"     json:"line,omitempty"`
 }
 
 type LyricLine struct {
-	Start int    `xml:"start,attr"`
-	Text  string `xml:",chardata"`
+	Start int    `xml:"start,attr"  json:"start"`
+	Text  string `xml:",chardata"   json:"value,omitempty"`
 	// Navidrome 0.51.0 - 0.52.5 incorrecty returns the lyric line text here
 	// This will be removed in the future
-	Value string `xml:"value"`
+	Value string `xml:"value" json:"-"`
 }
 
 type ItemDate struct {
-	Year  *int `xml:"year,attr,omitempty"`
-	Month *int `xml:"month,attr,omitempty"`
-	Day   *int `xml:"day,attr,omitempty"`
+	Year  *int `xml:"year,attr,omitempty"  json:"year,omitempty"`
+	Month *int `xml:"month,attr,omitempty" json:"month,omitempty"`
+	Day   *int `xml:"day,attr,omitempty"   json:"day,omitempty"`
 }
 
 type Contributor struct {
-	Role   string `xml:"role,attr"`
-	Artist IDName `xml:"artist"`
+	Role   string `xml:"role,attr" json:"role"`
+	Artist IDName `xml:"artist"    json:"artist"`
 }
 
 type ReplayGain struct {
-	TrackGain float64 `xml:"trackGain,omitempty,attr"    json:"trackGain,omitempty"`
-	AlbumGain float64 `xml:"albumGain,omitempty,attr"    json:"albumGain,omitempty"`
-	TrackPeak float64 `xml:"trackPeak,omitempty,attr"    json:"trackPeak,omitempty"`
-	AlbumPeak float64 `xml:"albumPeak,omitempty,attr"    json:"albumPeak,omitempty"`
+	TrackGain float64 `xml:"trackGain,omitempty,attr" json:"trackGain,omitempty"`
+	AlbumGain float64 `xml:"albumGain,omitempty,attr" json:"albumGain,omitempty"`
+	TrackPeak float64 `xml:"trackPeak,omitempty,attr" json:"trackPeak,omitempty"`
+	AlbumPeak float64 `xml:"albumPeak,omitempty,attr" json:"albumPeak,omitempty"`
 }
 
 type PlayQueueByIndex struct {
-	Entries      []*Child  `xml:"entry,omitempty"`
-	CurrentIndex int64     `xml:"currentIndex,attr,omitempty"`
-	Position     int64     `xml:"position,attr,omitempty"`
-	Username     string    `xml:"username,attr"`
-	Changed      time.Time `xml:"changed,attr"`
-	ChangedBy    string    `xml:"changedBy,attr"`
+	Entries      []*Child  `xml:"entry,omitempty"             json:"entry,omitempty"`
+	CurrentIndex int64     `xml:"currentIndex,attr,omitempty" json:"currentIndex,omitempty"`
+	Position     int64     `xml:"position,attr,omitempty"     json:"position,omitempty"`
+	Username     string    `xml:"username,attr"               json:"username"`
+	Changed      time.Time `xml:"changed,attr"                json:"changed"`
+	ChangedBy    string    `xml:"changedBy,attr"              json:"changedBy"`
+}
+
+func (t *PlayQueueByIndex) MarshalJSON() ([]byte, error) {
+	type T PlayQueueByIndex
+	var layout struct {
+		*T
+		Changed *xsdDateTime `json:"changed"`
+	}
+	layout.T = (*T)(t)
+	layout.Changed = (*xsdDateTime)(&t.Changed)
+	return json.Marshal(layout)
+}
+
+func (t *PlayQueueByIndex) UnmarshalJSON(data []byte) error {
+	type T PlayQueueByIndex
+	var overlay struct {
+		*T
+		Changed *xsdDateTime `json:"changed"`
+	}
+	overlay.T = (*T)(t)
+	overlay.Changed = (*xsdDateTime)(&overlay.T.Changed)
+	return json.Unmarshal(data, &overlay)
 }


### PR DESCRIPTION
## Summary

- Add `UseJSON bool` field to `Client` — when set, appends `&f=json` to all API requests and parses responses as JSON instead of XML
- Add `json` struct tags to all models matching Subsonic JSON API field names (camelCase, matching XML attribute names)
- Add `MarshalJSON`/`UnmarshalJSON` methods to all structs with `time.Time` fields using the same `xsdDateTime` overlay pattern as the existing XML methods, ensuring timestamps like `"2004-11-27T20:23:32"` parse correctly
- Map XML chardata fields (`Genre.Name`, `Lyrics.Text`, `LyricLine.Text`) to `json:"value"` per Subsonic JSON convention
- Keep the package-level `unmarshalResponse` function (XML-only) intact so existing tests remain unaffected

## Usage

```go
client := subsonic.Client{
    Client:     &http.Client{},
    BaseUrl:    "https://your-server",
    User:       "user",
    ClientName: "my-app",
    UseJSON:    true, // opt in to JSON
}
```

## Test plan

- [x] All existing unit tests pass (`TestUnmarshal*`, `Test_GetOpenSubsonicExtensions`)
- [x] Verify against a live Subsonic/Navidrome server with `UseJSON: true`
- [x] Verify `UseJSON: false` (default) continues to behave identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)